### PR TITLE
Refactor provider stats tracking

### DIFF
--- a/providers/abuseipdb/abuseipdb.go
+++ b/providers/abuseipdb/abuseipdb.go
@@ -155,12 +155,7 @@ func (c *Client) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising abuseipdb client")
 
@@ -168,12 +163,7 @@ func (c *Client) Initialise() error {
 }
 
 func (c *Client) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	result, err := fetchData(c.Session)
 	if err != nil {
@@ -186,12 +176,7 @@ func (c *Client) FindHost() ([]byte, error) {
 }
 
 func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	rowEmphasisColor := providers.RowEmphasisColor(c.Session)
 
@@ -402,9 +387,7 @@ func fetchData(c session.Session) (*HostSearchResult, error) {
 
 			result.Raw = item.Value
 
-			c.Stats.Mu.Lock()
-			c.Stats.FindHostUsedCache[ProviderName] = true
-			c.Stats.Mu.Unlock()
+			c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 			return result, nil
 		}

--- a/providers/annotated/annotated.go
+++ b/providers/annotated/annotated.go
@@ -247,12 +247,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("no paths provided for annotated provider")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising annotated client")
 
@@ -314,12 +309,7 @@ func generateURLsHash(urls []string) string {
 type HostSearchResult map[netip.Prefix][]annotation
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	var err error
 
@@ -417,12 +407,7 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var err error
 
@@ -504,9 +489,7 @@ func (c *ProviderClient) loadProviderDataFromCache() (map[netip.Prefix][]annotat
 
 			c.Logger.Info("annotated response found in cache", "host", c.Host.String())
 
-			c.Stats.Mu.Lock()
-			c.Stats.FindHostUsedCache[ProviderName] = true
-			c.Stats.Mu.Unlock()
+			c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 			return result, nil
 		}

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -160,12 +160,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising aws client")
 
@@ -223,20 +218,13 @@ func (c *ProviderClient) loadProviderDataFromCache() (*aws.Doc, error) {
 		return nil, fmt.Errorf("error reading aws provider cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 	return doc, nil
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var out []byte
 
@@ -340,12 +328,7 @@ func matchIPv4ToDoc(host netip.Addr, doc *aws.Doc) (*HostSearchResult, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	var result HostSearchResult
 

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -164,12 +164,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising azure client")
 
@@ -230,20 +225,13 @@ func (c *ProviderClient) loadProviderDataFromCache() (*azure.Doc, error) {
 		return nil, fmt.Errorf("error reading azure provider data from cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 	return doc, nil
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var out []byte
 
@@ -317,12 +305,7 @@ func matchIPToDoc(host netip.Addr, doc *azure.Doc) (*HostSearchResult, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	var err error
 

--- a/providers/azurewaf/azurewaf.go
+++ b/providers/azurewaf/azurewaf.go
@@ -142,12 +142,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising azure waf client")
 
@@ -205,20 +200,13 @@ func (c *ProviderClient) loadProviderDataFromCache() ([]*armfrontdoor.WebApplica
 		return nil, fmt.Errorf("%w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 	return doc, nil
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var out []byte
 
@@ -341,12 +329,7 @@ func matchIPToPolicyCustomRules(host netip.Addr, policies []*armfrontdoor.WebApp
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	rowEmphasisColor := providers.RowEmphasisColor(c.Session)
 

--- a/providers/bingbot/bingbot.go
+++ b/providers/bingbot/bingbot.go
@@ -172,12 +172,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising bingbot client")
 
@@ -225,9 +220,7 @@ func (c *ProviderClient) loadProviderDataFromCache() (*bingbot.Doc, error) {
 		return nil, fmt.Errorf("error reading bingbot cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 	return doc, nil
 }
@@ -250,12 +243,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 
 // FindHost searches for the host in the bingbot data
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var result *HostSearchResult
 
@@ -320,12 +308,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/criminalip/criminalip.go
+++ b/providers/criminalip/criminalip.go
@@ -269,9 +269,7 @@ func fetchData(client session.Session) (*HostSearchResult, error) {
 
 			result.Raw = item.Value
 
-			client.Stats.Mu.Lock()
-			client.Stats.FindHostUsedCache[ProviderName] = true
-			client.Stats.Mu.Unlock()
+			client.Stats.MarkCacheUsed(client.Stats.FindHostUsedCache, ProviderName)
 
 			return result, nil
 		}
@@ -339,12 +337,7 @@ func (c *Client) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising criminalip client")
 
@@ -364,12 +357,7 @@ func (c *Client) Initialise() error {
 }
 
 func (c *Client) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	if c.UseTestData {
 		return loadTestData(c)
@@ -479,12 +467,7 @@ func GenIssuesOutputForTable(in Issues) string {
 }
 
 func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -173,12 +173,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising digitalocean client")
 
@@ -226,9 +221,7 @@ func (c *ProviderClient) loadProviderDataFromCache() (*digitalocean.Doc, error) 
 		return nil, fmt.Errorf("error reading digitalocean cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 	return doc, nil
 }
@@ -251,12 +244,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 
 // FindHost searches for the host in the digitalocean data
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var result *HostSearchResult
 
@@ -304,12 +292,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -172,12 +172,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising gcp client")
 
@@ -225,9 +220,7 @@ func (c *ProviderClient) loadProviderDataFromCache() (*gcp.Doc, error) {
 		return nil, fmt.Errorf("error reading gcp cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 	return doc, nil
 }
@@ -250,12 +243,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 
 // FindHost searches for the host in the gcp data
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var result *HostSearchResult
 
@@ -326,12 +314,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -154,12 +154,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising google client")
 
@@ -207,10 +202,7 @@ func (c *ProviderClient) loadProviderDataFromCache() (*google.Doc, error) {
 		return nil, fmt.Errorf("error reading google cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
-
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 	return doc, nil
 }
 
@@ -232,12 +224,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 
 // FindHost searches for the host in the google data
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var result *HostSearchResult
 
@@ -302,12 +289,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/googlebot/googlebot.go
+++ b/providers/googlebot/googlebot.go
@@ -172,12 +172,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising googlebot client")
 
@@ -225,10 +220,7 @@ func (c *ProviderClient) loadProviderDataFromCache() (*googlebot.Doc, error) {
 		return nil, fmt.Errorf("error reading googlebot cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
-
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 	return doc, nil
 }
 
@@ -250,12 +242,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 
 // FindHost searches for the host in the googlebot data
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var result *HostSearchResult
 
@@ -320,12 +307,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/googlesc/googlesc.go
+++ b/providers/googlesc/googlesc.go
@@ -172,12 +172,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising googlesc client")
 
@@ -225,10 +220,7 @@ func (c *ProviderClient) loadProviderDataFromCache() (*googlesc.Doc, error) {
 		return nil, fmt.Errorf("error reading googlesc cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
-
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 	return doc, nil
 }
 
@@ -250,12 +242,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 
 // FindHost searches for the host in the googlesc data
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var result *HostSearchResult
 
@@ -320,12 +307,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -206,12 +206,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising icloudpr client")
 
@@ -280,9 +275,7 @@ func (c *ProviderClient) loadProviderDataFromCache(is4, is6 bool) (*icloudpr.Doc
 		return nil, fmt.Errorf("error reading icloudpr cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 	return doc, nil
 }
@@ -305,12 +298,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 
 // FindHost searches for the host in the icloudpr data
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var result *HostSearchResult
 
@@ -362,12 +350,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/ipapi/ipapi.go
+++ b/providers/ipapi/ipapi.go
@@ -130,12 +130,7 @@ func (c *Client) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Session.Stats.Mu.Lock()
-		c.Session.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Session.Stats.Mu.Unlock()
-	}()
+	defer c.Session.Stats.TrackDuration(c.Session.Stats.InitialiseDuration, ProviderName)()
 
 	c.Session.Logger.Debug("initialising ipapi client")
 
@@ -143,12 +138,7 @@ func (c *Client) Initialise() error {
 }
 
 func (c *Client) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Session.Stats.Mu.Lock()
-		c.Session.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Session.Stats.Mu.Unlock()
-	}()
+	defer c.Session.Stats.TrackDuration(c.Session.Stats.FindHostDuration, ProviderName)()
 
 	result, err := fetchData(c.Session)
 	if err != nil {
@@ -161,12 +151,7 @@ func (c *Client) FindHost() ([]byte, error) {
 }
 
 func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Session.Stats.Mu.Lock()
-		c.Session.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Session.Stats.Mu.Unlock()
-	}()
+	defer c.Session.Stats.TrackDuration(c.Session.Stats.CreateTableDuration, ProviderName)()
 
 	if data == nil {
 		return nil, nil
@@ -338,9 +323,7 @@ func fetchData(c session.Session) (*HostSearchResult, error) {
 
 			result.Raw = item.Value
 
-			c.Stats.Mu.Lock()
-			c.Stats.FindHostUsedCache[ProviderName] = true
-			c.Stats.Mu.Unlock()
+			c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 			return result, nil
 		}

--- a/providers/ipqs/ipqs.go
+++ b/providers/ipqs/ipqs.go
@@ -248,12 +248,7 @@ func (c *Client) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Session.Stats.Mu.Lock()
-		c.Session.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Session.Stats.Mu.Unlock()
-	}()
+	defer c.Session.Stats.TrackDuration(c.Session.Stats.InitialiseDuration, ProviderName)()
 
 	c.Session.Logger.Debug("initialising ipqs client")
 
@@ -261,12 +256,7 @@ func (c *Client) Initialise() error {
 }
 
 func (c *Client) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Session.Stats.Mu.Lock()
-		c.Session.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Session.Stats.Mu.Unlock()
-	}()
+	defer c.Session.Stats.TrackDuration(c.Session.Stats.FindHostDuration, ProviderName)()
 
 	result, err := fetchData(c.Session)
 	if err != nil {
@@ -279,12 +269,7 @@ func (c *Client) FindHost() ([]byte, error) {
 }
 
 func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Session.Stats.Mu.Lock()
-		c.Session.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Session.Stats.Mu.Unlock()
-	}()
+	defer c.Session.Stats.TrackDuration(c.Session.Stats.CreateTableDuration, ProviderName)()
 
 	if data == nil {
 		return nil, nil
@@ -564,9 +549,7 @@ func fetchData(c session.Session) (*HostSearchResult, error) {
 
 			result.Raw = item.Value
 
-			c.Stats.Mu.Lock()
-			c.Stats.FindHostUsedCache[ProviderName] = true
-			c.Stats.Mu.Unlock()
+			c.Session.Stats.MarkCacheUsed(c.Session.Stats.FindHostUsedCache, ProviderName)
 
 			return result, nil
 		}

--- a/providers/ipurl/ipurl.go
+++ b/providers/ipurl/ipurl.go
@@ -115,12 +115,7 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	if c.UseTestData {
 		return loadTestData()
@@ -180,12 +175,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising ipurl client")
 
@@ -225,9 +215,7 @@ func (c *ProviderClient) refreshURLCache() error {
 		"not in cache", len(refreshList))
 
 	if len(refreshList) == 0 {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseUsedCache[ProviderName] = true
-		c.Stats.Mu.Unlock()
+		c.Stats.MarkCacheUsed(c.Stats.InitialiseUsedCache, ProviderName)
 
 		return nil
 	}
@@ -363,9 +351,7 @@ func (c *ProviderClient) loadProviderDataFromCache(pwp map[netip.Prefix][]string
 		}
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 	return nil
 }
@@ -393,12 +379,7 @@ func unmarshalResponse(rBody []byte) (HostSearchResult, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -172,12 +172,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising linode client")
 
@@ -225,10 +220,7 @@ func (c *ProviderClient) loadProviderDataFromCache() (*linode.Doc, error) {
 		return nil, fmt.Errorf("error reading linode cache: %w", err)
 	}
 
-	c.Stats.Mu.Lock()
-	c.Stats.FindHostUsedCache[ProviderName] = true
-	c.Stats.Mu.Unlock()
-
+	c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 	return doc, nil
 }
 
@@ -250,12 +242,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 
 // FindHost searches for the host in the linode data
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	var result *HostSearchResult
 
@@ -307,12 +294,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	result, err := unmarshalResponse(data)
 	if err != nil {

--- a/providers/shodan/shodan.go
+++ b/providers/shodan/shodan.go
@@ -320,9 +320,7 @@ func fetchData(c session.Session) (*HostSearchResult, error) {
 
 			result.Raw = item.Value
 
-			c.Stats.Mu.Lock()
-			c.Stats.FindHostUsedCache[ProviderName] = true
-			c.Stats.Mu.Unlock()
+			c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 			return result, nil
 		}
@@ -357,12 +355,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising shodan client")
 
@@ -370,12 +363,7 @@ func (c *ProviderClient) Initialise() error {
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	result, err := fetchData(c.Session)
 	if err != nil {
@@ -554,12 +542,7 @@ func appendSSLRows(ssl Ssl, globalIndentSpaces int, rowEmphasisColor func(format
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	var result *HostSearchResult
 	if err := json.Unmarshal(data, &result); err != nil {

--- a/providers/virustotal/virustotal.go
+++ b/providers/virustotal/virustotal.go
@@ -344,9 +344,7 @@ func fetchData(c session.Session) (*HostSearchResult, error) {
 
 			result.Raw = item.Value
 
-			c.Stats.Mu.Lock()
-			c.Stats.FindHostUsedCache[ProviderName] = true
-			c.Stats.Mu.Unlock()
+			c.Stats.MarkCacheUsed(c.Stats.FindHostUsedCache, ProviderName)
 
 			return result, nil
 		}
@@ -381,12 +379,7 @@ func (c *ProviderClient) Initialise() error {
 		return errors.New("cache not set")
 	}
 
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.InitialiseDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.InitialiseDuration, ProviderName)()
 
 	c.Logger.Debug("initialising virustotal client")
 
@@ -398,12 +391,7 @@ func (c *ProviderClient) Initialise() error {
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.FindHostDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.FindHostDuration, ProviderName)()
 
 	result, err := fetchData(c.Session)
 	if err != nil {
@@ -585,12 +573,7 @@ func (lra LastAnalysisResults) GetTableRows(sess *session.Session, tw table.Writ
 }
 
 func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
-	start := time.Now()
-	defer func() {
-		c.Stats.Mu.Lock()
-		c.Stats.CreateTableDuration[ProviderName] = time.Since(start)
-		c.Stats.Mu.Unlock()
-	}()
+	defer c.Stats.TrackDuration(c.Stats.CreateTableDuration, ProviderName)()
 
 	rowEmphasisColor := providers.RowEmphasisColor(c.Session)
 

--- a/session/stats.go
+++ b/session/stats.go
@@ -1,0 +1,21 @@
+package session
+
+import "time"
+
+// TrackDuration records the elapsed time since invocation for the given provider.
+func (s *Stats) TrackDuration(m map[string]time.Duration, provider string) func() {
+	start := time.Now()
+
+	return func() {
+		s.Mu.Lock()
+		m[provider] = time.Since(start)
+		s.Mu.Unlock()
+	}
+}
+
+// MarkCacheUsed marks the cache as used for the given provider.
+func (s *Stats) MarkCacheUsed(m map[string]bool, provider string) {
+	s.Mu.Lock()
+	m[provider] = true
+	s.Mu.Unlock()
+}


### PR DESCRIPTION
## Summary
- add `TrackDuration` and `MarkCacheUsed` helpers
- refactor providers to use new stats helpers

## Testing
- `golangci-lint run ./...` *(fails: unsupported config version)*