### PR TITLE
Refactor duplication in utilities

### DIFF
--- a/manager/manager.go
+++ b/manager/manager.go
@@ -47,7 +47,7 @@ func (c *Client) CreateItemsInfoTable(info []CacheItemInfo) (*table.Writer, erro
 			estimatedSize = uint64(x.EstimatedSize) //nolint:gosec
 		}
 
-		tw.AppendRow(table.Row{x.Key, x.ExpiresAt.Format(timeFormat), humanize.Bytes(estimatedSize), present.DashIfEmpty(x.AppVersion)})
+		tw.AppendRow(table.Row{x.Key, x.ExpiresAt.Format(timeFormat), humanize.Bytes(estimatedSize), providers.DashIfEmpty(x.AppVersion)})
 	}
 
 	tw.SetColumnConfigs([]table.ColumnConfig{

--- a/present/present.go
+++ b/present/present.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/jonhadfield/ipscout/providers"
 
@@ -45,34 +44,6 @@ func JSON(jms *json.RawMessage) error {
 	fmt.Println(out.String())
 
 	return nil
-}
-
-func DashIfEmpty(value interface{}) string {
-	switch v := value.(type) {
-	case time.Time:
-		if v.IsZero() || v.Equal(time.Date(0o001, time.January, 1, 0, 0, 0, 0, time.UTC)) {
-			return "-"
-		}
-
-		return v.Format(providers.TimeFormat)
-	case string:
-		trimmed := strings.TrimSpace(v)
-		if len(trimmed) == 0 {
-			return "-"
-		}
-
-		return v
-	case *string:
-		if v == nil || len(strings.TrimSpace(*v)) == 0 {
-			return "-"
-		}
-
-		return *v
-	case int:
-		return fmt.Sprintf("%d", v)
-	default:
-		return "-"
-	}
 }
 
 type CombinedData struct {

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"os"
 	"time"
 
 	"github.com/jedib0t/go-pretty/v6/table"
@@ -190,7 +189,7 @@ func (c *ProviderClient) Initialise() error {
 }
 
 func loadTestData() ([]byte, error) {
-	tdf, err := loadResultsFile("providers/aws/testdata/aws_18_164_52_75_report.json")
+	tdf, err := providers.LoadResultsFile[HostSearchResult]("providers/aws/testdata/aws_18_164_52_75_report.json")
 	if err != nil {
 		return nil, err
 	}
@@ -396,24 +395,6 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	}
 
 	return &tw, nil
-}
-
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
-	jf, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("error opening file: %w", err)
-	}
-
-	defer jf.Close()
-
-	decoder := json.NewDecoder(jf)
-
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding json: %w", err)
-	}
-
-	return res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/ipqs/ipqs.go
+++ b/providers/ipqs/ipqs.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"net/netip"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -499,26 +498,8 @@ func loadResponse(c session.Session) (res *HostSearchResult, err error) {
 	return res, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
-	jf, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("error opening ipqs file: %w", err)
-	}
-
-	defer jf.Close()
-
-	decoder := json.NewDecoder(jf)
-
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding ipqs file: %w", err)
-	}
-
-	return res, nil
-}
-
 func loadTestData(l *slog.Logger) (*HostSearchResult, error) {
-	tdf, err := loadResultsFile("providers/ipqs/testdata/ipqs_74_125_219_32_report.json")
+	tdf, err := providers.LoadResultsFile[HostSearchResult]("providers/ipqs/testdata/ipqs_74_125_219_32_report.json")
 	if err != nil {
 		return nil, err
 	}

--- a/providers/ipurl/ipurl.go
+++ b/providers/ipurl/ipurl.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/netip"
-	"os"
 	"sync"
 	"time"
 
@@ -83,7 +82,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 }
 
 func loadTestData() ([]byte, error) {
-	tdf, err := loadResultsFile("providers/ipurl/testdata/ipurl_5_105_62_60_report.json")
+	tdf, err := providers.LoadResultsFile[HostSearchResult]("providers/ipurl/testdata/ipurl_5_105_62_60_report.json")
 	if err != nil {
 		return nil, err
 	}
@@ -94,24 +93,6 @@ func loadTestData() ([]byte, error) {
 	}
 
 	return out, nil
-}
-
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
-	jf, err := os.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("error opening file: %w", err)
-	}
-
-	defer jf.Close()
-
-	decoder := json.NewDecoder(jf)
-
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding json: %w", err)
-	}
-
-	return res, nil
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -469,3 +469,23 @@ func UpdateScoreIfLarger(a *float64, b float64) {
 		*a = b
 	}
 }
+
+// LoadResultsFile reads JSON data from path and unmarshals it into the supplied
+// type. It is primarily used for loading provider test data.
+func LoadResultsFile[T any](path string) (*T, error) {
+	jf, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("error opening file: %w", err)
+	}
+
+	defer jf.Close()
+
+	decoder := json.NewDecoder(jf)
+
+	var res T
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
+	}
+
+	return &res, nil
+}


### PR DESCRIPTION
## Summary
- remove duplicate `DashIfEmpty` function
- share JSON loader via `LoadResultsFile`
- update providers to use new helper

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.21.0.3:8080: connect: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683c456bceac83208843ac013eda1af2