### PR TITLE
Refactor error handling and returns

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/jonhadfield/ipscout/providers/hetzner"
 	"log/slog"
@@ -110,7 +111,7 @@ func getEnabledProviderClients(sess session.Session) (map[string]providers.Provi
 	}
 
 	if enabled == 0 {
-		return nil, fmt.Errorf("no providers enabled")
+		return nil, errors.New("no providers enabled")
 	}
 
 	return runners, nil

--- a/providers/abuseipdb/abuseipdb.go
+++ b/providers/abuseipdb/abuseipdb.go
@@ -265,7 +265,7 @@ func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadAPIResponse(ctx context.Context, c session.Session, apiKey string) (res *HostSearchResult, err error) {
+func loadAPIResponse(ctx context.Context, c session.Session, apiKey string) (*HostSearchResult, error) {
 	urlPath, err := url.JoinPath(APIURL, HostIPPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create abuseipdb api url path: %w", err)
@@ -314,7 +314,7 @@ func loadAPIResponse(ctx context.Context, c session.Session, apiKey string) (res
 		return nil, providers.ErrNoDataFound
 	}
 
-	res, err = unmarshalResponse(rBody)
+	res, err := unmarshalResponse(rBody)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling response: %w", err)
 	}
@@ -339,7 +339,7 @@ func unmarshalResponse(data []byte) (*HostSearchResult, error) {
 	return &res, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening abuseipdb file: %w", err)
@@ -347,14 +347,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding abuseipdb file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding abuseipdb file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 func (ssr *HostSearchResult) CreateTable() *table.Writer {

--- a/providers/annotated/annotated.go
+++ b/providers/annotated/annotated.go
@@ -88,7 +88,8 @@ func annotationNotesContain(notes []string, term string) bool {
 	return false
 }
 
-func extractThreatAnnotations(ae []annotation) (threats []string) {
+func extractThreatAnnotations(ae []annotation) []string {
+	var threats []string
 	for y := range ae {
 		for z := range ae[y].Notes {
 			if strings.HasPrefix(ae[y].Notes[z], "threat:") {
@@ -97,7 +98,7 @@ func extractThreatAnnotations(ae []annotation) (threats []string) {
 		}
 	}
 
-	return
+	return threats
 }
 
 func (c *ProviderClient) ExtractThreatIndicators(findRes []byte) (*providers.ThreatIndicators, error) {
@@ -224,7 +225,9 @@ func ReadAnnotatedPrefixesFromFile(l *slog.Logger, path string, prefixesWithAnno
 	return nil
 }
 
-func parseAndRepackYAMLAnnotations(l *slog.Logger, source string, yas []yamlAnnotation) (pyas []annotation) {
+func parseAndRepackYAMLAnnotations(l *slog.Logger, source string, yas []yamlAnnotation) []annotation {
+	var pyas []annotation
+
 	for _, ya := range yas {
 		pDate, err := dateparse.ParseAny(ya.Date, dateparse.PreferMonthFirst(false))
 		if err != nil {
@@ -239,7 +242,7 @@ func parseAndRepackYAMLAnnotations(l *slog.Logger, source string, yas []yamlAnno
 		})
 	}
 
-	return
+	return pyas
 }
 
 func (c *ProviderClient) Initialise() error {
@@ -398,7 +401,7 @@ func loadTestData() ([]byte, error) {
 	return out, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -406,14 +409,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding json: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding json: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 func (c *ProviderClient) FindHost() ([]byte, error) {
@@ -523,7 +526,8 @@ type Repository struct {
 	Patterns    []string `toml:"patterns"`
 }
 
-func getValidFilePathsFromDir(l *slog.Logger, dir string) (paths []os.DirEntry) {
+func getValidFilePathsFromDir(l *slog.Logger, dir string) []os.DirEntry {
+	var paths []os.DirEntry
 	files, err := os.ReadDir(dir)
 	if err != nil {
 		l.Warn("failed to read", "dir", dir, "error", err.Error())
@@ -541,7 +545,7 @@ func getValidFilePathsFromDir(l *slog.Logger, dir string) (paths []os.DirEntry) 
 		}
 	}
 
-	return
+	return paths
 }
 
 func LoadFilePrefixesWithAnnotationsFromPath(path string, prefixesWithAnnotations map[netip.Prefix][]annotation) error {

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -94,7 +94,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.IPPrefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in aws data")
+		return rateResult, errors.New("no prefix found in aws data")
 	}
 
 	if doc.IPPrefix.IsValid() || doc.IPv6Prefix.IPv6Prefix.IsValid() {

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -106,7 +106,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in azure data")
+		return rateResult, errors.New("no prefix found in azure data")
 	}
 
 	if doc.Prefix.IsValid() {
@@ -358,7 +358,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -366,14 +366,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/azurewaf/azurewaf.go
+++ b/providers/azurewaf/azurewaf.go
@@ -410,7 +410,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -422,14 +422,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 		}
 	}()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding json: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding json: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type PolicyMatch struct {

--- a/providers/bingbot/bingbot.go
+++ b/providers/bingbot/bingbot.go
@@ -95,7 +95,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in bingbot data")
+		return rateResult, errors.New("no prefix found in bingbot data")
 	}
 
 	if doc.Prefix.IsValid() {

--- a/providers/criminalip/criminalip.go
+++ b/providers/criminalip/criminalip.go
@@ -167,7 +167,7 @@ type Config struct {
 	APIKey string
 }
 
-func loadAPIResponse(ctx context.Context, conf *session.Session, apiKey string) (res *HostSearchResult, err error) {
+func loadAPIResponse(ctx context.Context, conf *session.Session, apiKey string) (*HostSearchResult, error) {
 	urlPath, err := url.JoinPath(APIURL, HostIPPath)
 	if err != nil {
 		return nil, fmt.Errorf("error joining criminal ip api url: %w", err)
@@ -215,7 +215,7 @@ func loadAPIResponse(ctx context.Context, conf *session.Session, apiKey string) 
 
 	defer resp.Body.Close()
 
-	res, err = unmarshalResponse(rBody)
+	res, err := unmarshalResponse(rBody)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling criminal ip response: %w", err)
 	}
@@ -589,7 +589,7 @@ func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -597,14 +597,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding criminalip data: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding criminalip data: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResultData struct {

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -95,7 +95,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Record.Network.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in digitalocean data")
+		return rateResult, errors.New("no prefix found in digitalocean data")
 	}
 
 	if doc.Record.Network.IsValid() {

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -95,7 +95,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in gcp data")
+		return rateResult, errors.New("no prefix found in gcp data")
 	}
 
 	if doc.Prefix.IsValid() {

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -77,7 +77,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in Google data")
+		return rateResult, errors.New("no prefix found in Google data")
 	}
 
 	if doc.Prefix.IsValid() {

--- a/providers/googlebot/googlebot.go
+++ b/providers/googlebot/googlebot.go
@@ -95,7 +95,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in Googlebot data")
+		return rateResult, errors.New("no prefix found in Googlebot data")
 	}
 
 	if doc.Prefix.IsValid() {

--- a/providers/googlesc/googlesc.go
+++ b/providers/googlesc/googlesc.go
@@ -95,7 +95,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in GoogleSC data")
+		return rateResult, errors.New("no prefix found in GoogleSC data")
 	}
 
 	if doc.Prefix.IsValid() {

--- a/providers/hetzner/hetzner.go
+++ b/providers/hetzner/hetzner.go
@@ -77,7 +77,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in Hetzner data")
+		return rateResult, errors.New("no prefix found in Hetzner data")
 	}
 
 	if doc.Prefix.IsValid() {

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -79,7 +79,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in iCloud Private Relay data")
+		return rateResult, errors.New("no prefix found in iCloud Private Relay data")
 	}
 
 	if doc.Prefix.IsValid() {

--- a/providers/ipapi/ipapi.go
+++ b/providers/ipapi/ipapi.go
@@ -240,8 +240,8 @@ type ipapiResp struct {
 	Hostname           string  `json:"hostname"`
 }
 
-func loadResponse(c session.Session) (res *HostSearchResult, err error) {
-	res = &HostSearchResult{}
+func loadResponse(c session.Session) (*HostSearchResult, error) {
+	res := &HostSearchResult{}
 
 	req, err := retryablehttp.NewRequest("GET", fmt.Sprintf("%s/%s/json", apiDomain, c.Host.String()), nil)
 	if err != nil {
@@ -273,7 +273,7 @@ func loadResponse(c session.Session) (res *HostSearchResult, err error) {
 	return res, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening ipapi file: %w", err)
@@ -281,14 +281,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding ipapi file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding ipapi file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 func loadTestData(l *slog.Logger) (*HostSearchResult, error) {

--- a/providers/ipqs/ipqs.go
+++ b/providers/ipqs/ipqs.go
@@ -432,12 +432,12 @@ type TransactionDetails struct {
 	AddressEmailIdentityMatch string   `json:"address_email_identity_match,omitempty"`
 }
 
-func loadResponse(c session.Session) (res *HostSearchResult, err error) {
+func loadResponse(c session.Session) (*HostSearchResult, error) {
 	if c.Providers.IPQS.APIKey == "" {
 		return nil, errors.New("IPQS API key not set")
 	}
 
-	res = &HostSearchResult{}
+	res := &HostSearchResult{}
 
 	urlPath, err := url.JoinPath(APIURL, c.Providers.IPQS.APIKey, c.Host.String())
 	if err != nil {
@@ -476,7 +476,7 @@ func loadResponse(c session.Session) (res *HostSearchResult, err error) {
 	}
 
 	if len(body) == 0 {
-		return nil, fmt.Errorf("ipqs response body is empty")
+		return nil, errors.New("ipqs response body is empty")
 	}
 
 	var apiResp ipqsResp

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -95,7 +95,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if doc.Prefix.String() == "" {
-		return rateResult, fmt.Errorf("no prefix found in linode data")
+		return rateResult, errors.New("no prefix found in linode data")
 	}
 
 	if doc.Prefix.IsValid() {
@@ -347,7 +347,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -355,14 +355,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -135,9 +135,9 @@ func PortNetworkMatch(incomingPort string, matchPorts []string) bool {
 func portAgeCheck(portConfirmedTime string, timeFormat string, maxAge string) (bool, error) {
 	switch {
 	case portConfirmedTime == "":
-		return false, fmt.Errorf("no port confirmed time provided")
+		return false, errors.New("no port confirmed time provided")
 	case timeFormat == "":
-		return false, fmt.Errorf("no time format provided")
+		return false, errors.New("no time format provided")
 	}
 
 	// if no age filter provided, then return true
@@ -178,7 +178,10 @@ type PortMatchFilterInput struct {
 
 // PortMatchFilter returns true by default, and false if either age or netmatch is specified
 // and doesn't match
-func PortMatchFilter(in PortMatchFilterInput) (ageMatch, netMatch bool, err error) {
+func PortMatchFilter(in PortMatchFilterInput) (bool, bool, error) {
+	var ageMatch bool
+	var netMatch bool
+	var err error
 	switch in.IncomingPort {
 	case "":
 		netMatch = true
@@ -190,7 +193,7 @@ func PortMatchFilter(in PortMatchFilterInput) (ageMatch, netMatch bool, err erro
 	case in.ConfirmedDate == "" && in.ConfirmedDateFormat == "":
 		ageMatch = true
 	case in.ConfirmedDate == "" || in.ConfirmedDateFormat == "":
-		return false, false, fmt.Errorf("both confirmed date and format must be specified")
+		return false, false, errors.New("both confirmed date and format must be specified")
 	default:
 		ageMatch, err = portAgeCheck(in.ConfirmedDate, in.ConfirmedDateFormat, in.MaxAge)
 		if err != nil {

--- a/providers/ptr/ptr.go
+++ b/providers/ptr/ptr.go
@@ -155,8 +155,8 @@ func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResponse(c session.Session) (res *HostSearchResult, err error) {
-	res = &HostSearchResult{}
+func loadResponse(c session.Session) (*HostSearchResult, error) {
+	res := &HostSearchResult{}
 
 	target := c.Host.String()
 
@@ -221,7 +221,7 @@ func loadResponse(c session.Session) (res *HostSearchResult, err error) {
 	return res, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening ptr file: %w", err)
@@ -229,14 +229,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding ptr file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding ptr file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 func loadTestData(l *slog.Logger) (*HostSearchResult, error) {

--- a/providers/virustotal/virustotal.go
+++ b/providers/virustotal/virustotal.go
@@ -175,7 +175,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 	}
 
 	if hostData.Data.ID == "" {
-		return providers.RateResult{}, fmt.Errorf("no host id found")
+		return providers.RateResult{}, errors.New("no host id found")
 	}
 
 	return rateHost(hostData.Data.Attributes, ratingConfig), nil
@@ -391,7 +391,7 @@ func (c *ProviderClient) Initialise() error {
 	c.Logger.Debug("initialising virustotal client")
 
 	if c.Providers.VirusTotal.APIKey == "" && !c.UseTestData {
-		return fmt.Errorf("virustotal provider api key not set")
+		return errors.New("virustotal provider api key not set")
 	}
 
 	return nil

--- a/rate/rate.go
+++ b/rate/rate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/jonhadfield/ipscout/providers/hetzner"
 	"log/slog"
@@ -429,7 +430,7 @@ func staticRateFindHostsResults(sess *session.Session, runners map[string]provid
 	}
 
 	if providersThatDetected == 0 {
-		return RatingOutput{}, fmt.Errorf("no providers detected")
+		return RatingOutput{}, errors.New("no providers detected")
 	}
 
 	aggregateScore := runningTotal / float64(providersThatDetected)

--- a/session/session.go
+++ b/session/session.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	_ "embed"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/netip"
@@ -82,11 +83,11 @@ func New() *Session {
 func (c *Session) Validate() error {
 	switch {
 	case c.Logger == nil:
-		return fmt.Errorf("logger not set")
+		return errors.New("logger not set")
 	case c.Stats == nil:
-		return fmt.Errorf("stats not set")
+		return errors.New("stats not set")
 	case c.Cache == nil:
-		return fmt.Errorf("cache not set")
+		return errors.New("cache not set")
 	}
 
 	return nil
@@ -285,7 +286,7 @@ func unmarshalConfig(data []byte) (*Session, error) {
 // and returns true if it was created, or false if it already exists
 func CreateDefaultConfigIfMissing(path string) (bool, error) {
 	if path == "" {
-		return false, fmt.Errorf("session path not specified")
+		return false, errors.New("session path not specified")
 	}
 
 	// check if session already exists


### PR DESCRIPTION
## Summary
- simplify error creation by using errors.New
- remove naked returns by using explicit variables
- drop named return parameters in many provider helpers
- clarify messages in provider utilities

## Testing
- `go test ./...` *(fails: no route to host)*

------
https://chatgpt.com/codex/tasks/task_e_683c99bd83bc83208f55a12c32e5f601