### PR TITLE
Fix panic usage and refine port handling

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -542,10 +542,8 @@ func initSessionConfig(sess *session.Session, v *viper.Viper) error {
 
 	sess.Config.Global.MaxAge = v.GetString("global.max_age")
 	sess.Config.Global.MaxReports = v.GetInt("global.max_reports")
-	// TODO: Nasty Hack Alert
-	// if not specified, ports is returned as a string: "[]"
-	// set to nil if that's the case
-	if len(sess.Config.Global.Ports) == 0 || sess.Config.Global.Ports[0] == "[]" {
+
+	if len(sess.Config.Global.Ports) == 1 && sess.Config.Global.Ports[0] == "[]" {
 		sess.Config.Global.Ports = nil
 	}
 
@@ -616,10 +614,7 @@ func initConfig(cmd *cobra.Command) error {
 	sess.UseTestData = utd
 
 	ports, _ := cmd.Flags().GetStringSlice("ports")
-	// TODO: Nasty Hack Alert
-	// if not specified, ports is returned as a string: "[]"
-	// set to nil if that's the case
-	if len(ports) == 0 || ports[0] == "[]" {
+	if len(ports) == 1 && ports[0] == "[]" {
 		ports = nil
 	}
 	// if no ports specified on cli then default to global ports

--- a/providers/abuseipdb/abuseipdb.go
+++ b/providers/abuseipdb/abuseipdb.go
@@ -273,7 +273,7 @@ func loadAPIResponse(ctx context.Context, c session.Session, apiKey string) (*Ho
 
 	sURL, err := url.Parse(urlPath)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to parse abuseipdb api url: %w", err)
 	}
 
 	sURL.RawQuery = fmt.Sprintf("ipAddress=%s&verbose=false&maxAgeInDays=1", c.Host.String())

--- a/providers/shodan/shodan.go
+++ b/providers/shodan/shodan.go
@@ -76,7 +76,7 @@ func loadAPIResponse(ctx context.Context, c session.Session, apiKey string) (*Ho
 
 	sURL, err := url.Parse(urlPath)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to parse shodan api url: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, APITimeout)

--- a/providers/virustotal/virustotal.go
+++ b/providers/virustotal/virustotal.go
@@ -208,7 +208,7 @@ func loadAPIResponse(ctx context.Context, c session.Session, apiKey string) (res
 
 	sURL, err := url.Parse(urlPath)
 	if err != nil {
-		panic(err)
+		return nil, fmt.Errorf("failed to parse virustotal api url: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, APITimeout)


### PR DESCRIPTION
## Summary
- avoid `panic` in provider API functions
- treat empty CLI/config port slices correctly

## Testing
- `go test ./...` *(fails: no network access)*

------
https://chatgpt.com/codex/tasks/task_e_683df0e21d748320be13c9c751b697fd