### PR TITLE
Add FQDN input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ This will create an `ipscout` binary in the current directory.
 ## Usage
 
 ```shell
-$ ipscout <ip address>
+$ ipscout <host>
 ```
+`<host>` can be an IP address or a fully qualified domain name.
 
 ## Configuration
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ func newRootCommand() *cobra.Command {
 	)
 
 	rootCmd := &cobra.Command{
-		Use:           "ipscout [options] <ip address>",
+		Use:           "ipscout [options] <host>",
 		Short:         "ipscout [command]",
 		Long:          `IPScout searches providers for information about hosts`,
 		Args:          cobra.MinimumNArgs(0),
@@ -82,7 +82,7 @@ func newRootCommand() *cobra.Command {
 
 		var err error
 
-		if sess.Host, err = netip.ParseAddr(args[0]); err != nil {
+		if sess.Host, err = parseHost(args[0]); err != nil {
 			return fmt.Errorf("invalid host: %w", err)
 		}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
+	"net"
+	"net/netip"
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
@@ -20,4 +24,32 @@ func getHTTPClient() *retryablehttp.Client {
 	hc.Logger = nil
 
 	return hc
+}
+
+// parseHost attempts to convert the provided argument into a netip.Addr. If the
+// argument isn't already an IP address, it is treated as a hostname and
+// resolved using the system resolver.
+func parseHost(arg string) (netip.Addr, error) {
+	if addr, err := netip.ParseAddr(arg); err == nil {
+		return addr, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", arg)
+	if err != nil {
+		return netip.Addr{}, fmt.Errorf("failed to resolve host: %w", err)
+	}
+
+	if len(ips) == 0 {
+		return netip.Addr{}, fmt.Errorf("no ip addresses found for %s", arg)
+	}
+
+	addr, err := netip.ParseAddr(ips[0].String())
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	return addr, nil
 }

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseHost(t *testing.T) {
+	t.Run("ip", func(t *testing.T) {
+		addr, err := parseHost("1.1.1.1")
+		require.NoError(t, err)
+		require.Equal(t, netip.MustParseAddr("1.1.1.1"), addr)
+	})
+
+	t.Run("fqdn", func(t *testing.T) {
+		addr, err := parseHost("localhost")
+		require.NoError(t, err)
+		require.True(t, addr.IsLoopback())
+	})
+}


### PR DESCRIPTION
## Summary
- resolve hostnames to IPs before processing
- update CLI usage to reflect hostname support
- document ability to use hostnames
- add tests for hostname parsing

## Testing
- `go test ./...` *(fails: Forbidden downloading go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_68454fbec45083208f88bed02d88ad03