### PR TITLE
Refactor to consolidate constants

### DIFF
--- a/cache/messages.go
+++ b/cache/messages.go
@@ -1,0 +1,9 @@
+package cache
+
+const (
+	ErrReadCacheItemFmt    = "error reading cache item: %w"
+	ErrMarshalItemFmt      = "error marshalling item: %w"
+	ErrDeleteCacheItemsFmt = "error deleting cache items: %w"
+	ErrIteratingCacheFmt   = "error iterating cache: %w"
+	ErrReadCacheFmt        = "error reading cache: %w"
+)

--- a/config/config.go
+++ b/config/config.go
@@ -19,17 +19,9 @@ import (
 	"github.com/jonhadfield/ipscout/session"
 )
 
-const (
-	maxColumnWidth = 60
-	indentSpaces   = 2
-	minTableWidth  = 20
-)
-
 type Client struct {
 	Sess *session.Session
 }
-
-var timeFormat = "2006-01-02 15:04:05 MST"
 
 func (c *Client) CreateConfigTable() (*table.Writer, error) {
 	tw := table.NewWriter()
@@ -61,7 +53,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		abuseipdbEnabled = *c.Sess.Providers.AbuseIPDB.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), abuseipdbEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), abuseipdbEnabled})
 
 	// annotated
 
@@ -72,7 +64,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		annotatedEnabled = *c.Sess.Providers.Annotated.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), annotatedEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), annotatedEnabled})
 
 	for x, path := range c.Sess.Providers.Annotated.Paths {
 		var pathsTitle string
@@ -80,7 +72,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 			pathsTitle = "paths"
 		}
 
-		tw.AppendRow(table.Row{color.WhiteString("%s%s", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces), pathsTitle), path})
+		tw.AppendRow(table.Row{color.WhiteString("%s%s", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces), pathsTitle), path})
 	}
 
 	// aws
@@ -91,7 +83,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		awsEnabled = *c.Sess.Providers.AWS.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), awsEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), awsEnabled})
 
 	// azure
 	tw.AppendRow(table.Row{color.HiCyanString("%sAzure", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -101,7 +93,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		azureEnabled = *c.Sess.Providers.Azure.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), azureEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), azureEnabled})
 
 	// criminalip
 	tw.AppendRow(table.Row{color.HiCyanString("%sCriminalIP", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -111,7 +103,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		criminalipEnabled = *c.Sess.Providers.CriminalIP.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), criminalipEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), criminalipEnabled})
 
 	// digitalocean
 	tw.AppendRow(table.Row{color.HiCyanString("%sDigitalocean", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -121,7 +113,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		digitaloceanEnabled = *c.Sess.Providers.DigitalOcean.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), digitaloceanEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), digitaloceanEnabled})
 
 	// gcp
 	tw.AppendRow(table.Row{color.HiCyanString("%sGCP", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -131,7 +123,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		gcpEnabled = *c.Sess.Providers.GCP.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), gcpEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), gcpEnabled})
 
 	// google
 	tw.AppendRow(table.Row{color.HiCyanString("%sGoogle", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -141,7 +133,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		googleEnabled = *c.Sess.Providers.Google.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), googleEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), googleEnabled})
 
 	// googlebot
 	tw.AppendRow(table.Row{color.HiCyanString("%sGooglebot", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -151,7 +143,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		googlebotEnabled = *c.Sess.Providers.Googlebot.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), googlebotEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), googlebotEnabled})
 
 	// hetzner
 	tw.AppendRow(table.Row{color.HiCyanString("%sHetzner", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -161,7 +153,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		hetznerEnabled = *c.Sess.Providers.Hetzner.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), hetznerEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), hetznerEnabled})
 
 	// iCloud Private Relay
 	tw.AppendRow(table.Row{color.HiCyanString("%siCloud Private Relay", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -171,7 +163,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		icloudPREnabled = *c.Sess.Providers.ICloudPR.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), icloudPREnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), icloudPREnabled})
 
 	// ipapi
 	tw.AppendRow(table.Row{color.HiCyanString("%sIPAPI", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -181,7 +173,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		ipapiEnabled = *c.Sess.Providers.IPAPI.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), ipapiEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), ipapiEnabled})
 
 	// IPURL
 	tw.AppendRow(table.Row{color.HiCyanString("%sIPURL", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -191,7 +183,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		ipurlEnabled = *c.Sess.Providers.IPURL.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), ipurlEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), ipurlEnabled})
 
 	for x, url := range c.Sess.Providers.IPURL.URLs {
 		var urlsTitle string
@@ -200,7 +192,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 			urlsTitle = "urls"
 		}
 
-		tw.AppendRow(table.Row{color.WhiteString("%s%s", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces), urlsTitle), url})
+		tw.AppendRow(table.Row{color.WhiteString("%s%s", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces), urlsTitle), url})
 	}
 
 	// linode
@@ -212,7 +204,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		linodeEnabled = *c.Sess.Providers.Linode.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), linodeEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), linodeEnabled})
 
 	// ptr
 	tw.AppendRow(table.Row{color.HiCyanString("%sPTR", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -222,7 +214,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		ptrEnabled = *c.Sess.Providers.PTR.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), ptrEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), ptrEnabled})
 
 	// shodan
 	tw.AppendRow(table.Row{color.HiCyanString("%sShodan", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -232,7 +224,7 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		shodanEnabled = *c.Sess.Providers.Shodan.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), shodanEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), shodanEnabled})
 
 	// virustotal
 	tw.AppendRow(table.Row{color.HiCyanString("%sVirusTotal", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
@@ -242,11 +234,11 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 		virustotalEnabled = *c.Sess.Providers.VirusTotal.Enabled
 	}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), virustotalEnabled})
+	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), virustotalEnabled})
 
 	// end
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: 1, AutoMerge: false, WidthMax: maxColumnWidth, WidthMin: minTableWidth},
+		{Number: 1, AutoMerge: false, WidthMax: providers.MaxColumnWidth, WidthMin: providers.MinTableWidth},
 	})
 
 	tw.SetAutoIndex(false)
@@ -285,7 +277,7 @@ func (c *Client) Delete(keys []string) error {
 	defer db.Close()
 
 	if err = cache.DeleteMultiple(c.Sess.Logger, db, keys); err != nil {
-		return fmt.Errorf("error deleting cache items: %w", err)
+		return fmt.Errorf(cache.ErrDeleteCacheItemsFmt, err)
 	}
 
 	return nil
@@ -303,7 +295,7 @@ func (c *Client) Get(key string, raw bool) error {
 
 	item, err := cache.Read(c.Sess.Logger, db, key)
 	if err != nil {
-		return fmt.Errorf("error reading cache: %w", err)
+		return fmt.Errorf(cache.ErrReadCacheFmt, err)
 	}
 
 	if raw {
@@ -324,12 +316,12 @@ func (c *Client) Get(key string, raw bool) error {
 	pItem.Key = item.Key
 	pItem.AppVersion = item.AppVersion
 	pItem.Version = item.Version
-	pItem.Created = item.Created.Format(timeFormat)
+	pItem.Created = item.Created.Format(providers.TimeFormat)
 	pItem.Value = item.Value
 
 	out, err := json.MarshalIndent(&pItem, "", "  ")
 	if err != nil {
-		return fmt.Errorf("error marshalling item: %w", err)
+		return fmt.Errorf(cache.ErrMarshalItemFmt, err)
 	}
 
 	fmt.Printf("%s\n", out)
@@ -362,7 +354,7 @@ func (c *Client) GetCacheItemsInfo() ([]CacheItemInfo, error) {
 
 			ci, err := cache.Read(c.Sess.Logger, db, string(k))
 			if err != nil {
-				return fmt.Errorf("error reading cache item: %w", err)
+				return fmt.Errorf(cache.ErrReadCacheItemFmt, err)
 			}
 
 			var expiresAt int64
@@ -384,7 +376,7 @@ func (c *Client) GetCacheItemsInfo() ([]CacheItemInfo, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error iterating cache: %w", err)
+		return nil, fmt.Errorf(cache.ErrIteratingCacheFmt, err)
 	}
 
 	return cacheItemsInfo, nil

--- a/providers/abuseipdb/abuseipdb.go
+++ b/providers/abuseipdb/abuseipdb.go
@@ -31,7 +31,6 @@ const (
 	portLastModifiedFormat = "2006-01-02T15:04:05+07:00"
 	ResultTTL              = 12 * time.Hour
 	OutputPriority         = 40
-	dataColumnNo           = 2
 	veryHighScoreThreshold = 10
 	highScoreThreshold     = 7
 	mediumScoreThreshold   = 5
@@ -249,7 +248,7 @@ func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
 	}
 
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth, ColorsHeader: text.Colors{text.BgCyan}},
+		{Number: providers.DataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth, ColorsHeader: text.Colors{text.BgCyan}},
 	})
 	tw.SetAutoIndex(false)
 	// tw.SetStyle(table.StyleColoredDark)

--- a/providers/annotated/annotated.go
+++ b/providers/annotated/annotated.go
@@ -31,7 +31,6 @@ const (
 	ProviderName           = "annotated"
 	CacheTTL               = 5 * time.Minute
 	ipFileSuffixesToIgnore = "sh,conf"
-	dataColumnNo           = 2
 )
 
 type Annotated struct {
@@ -375,7 +374,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -17,7 +17,6 @@ import (
 const (
 	ProviderName = "aws"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -385,7 +384,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("AWS | Host: %s", c.Host.String())

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -19,7 +19,6 @@ import (
 const (
 	ProviderName = "azure"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -346,7 +345,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	tw.AppendRow(table.Row{"Net Features", providers.DashIfEmpty(strings.Join(result.Properties.NetworkFeatures, ","))})
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("AZURE | Host: %s", c.Host.String())

--- a/providers/azurewaf/azurewaf.go
+++ b/providers/azurewaf/azurewaf.go
@@ -27,7 +27,6 @@ const (
 	ProviderName      = "azurewaf"
 	DocTTL            = 1 * time.Hour
 	IndentPipeHyphens = " |-----"
-	dataColumnNo      = 2
 )
 
 type Config struct {
@@ -397,7 +396,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 		tw.AppendRows(rows)
 		tw.SetColumnConfigs([]table.ColumnConfig{
-			{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+			{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 		})
 		tw.SetAutoIndex(false)
 		tw.SetTitle("AZURE WAF | Host: %s", c.Host.String())

--- a/providers/bingbot/bingbot.go
+++ b/providers/bingbot/bingbot.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "bingbot"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -344,7 +343,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("BINGBOT | Host: %s", c.Host.String())

--- a/providers/criminalip/criminalip.go
+++ b/providers/criminalip/criminalip.go
@@ -29,7 +29,6 @@ const (
 	IndentPipeHyphens = " |-----"
 	ResultTTL         = 24 * time.Hour
 	APITimeout        = 30 * time.Second
-	dataColumnNo      = 2
 )
 
 type Client struct {
@@ -577,7 +576,7 @@ func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("CRIMINAL IP | Host: %s", c.Host.String())

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "digitalocean"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -337,7 +336,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("DIGITAL OCEAN | Host: %s", c.Host.String())

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "gcp"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -357,7 +356,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("GCP | Host: %s", c.Host.String())

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "google"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -327,7 +326,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("GOOGLE | Host: %s", c.Host.String())

--- a/providers/googlebot/googlebot.go
+++ b/providers/googlebot/googlebot.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "googlebot"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -345,7 +344,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("GOOGLEBOT | Host: %s", c.Host.String())

--- a/providers/googlesc/googlesc.go
+++ b/providers/googlesc/googlesc.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "googlesc"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -345,7 +344,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("GOOGLE SPECIAL CRAWLER | Host: %s", c.Host.String())

--- a/providers/hetzner/hetzner.go
+++ b/providers/hetzner/hetzner.go
@@ -19,7 +19,6 @@ import (
 const (
 	ProviderName = "hetzner"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -325,7 +324,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("HETZNER | Host: %s", c.Host.String())

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "icloudpr"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 var ErrInvalidIPVersion = errors.New("invalid ip version")
@@ -391,7 +390,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("ICLOUD PRIVATE RELAY | Host: %s", c.Host.String())

--- a/providers/ipapi/ipapi.go
+++ b/providers/ipapi/ipapi.go
@@ -24,7 +24,6 @@ const (
 	ProviderName = "ipapi"
 	ResultTTL    = 1 * time.Hour
 	apiDomain    = "https://ipapi.co"
-	dataColumnNo = 2
 )
 
 type Client struct {
@@ -193,7 +192,7 @@ func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
 	tw.AppendRow(table.Row{"ASN", providers.DashIfEmpty(findHostData.Asn)})
 
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 		{Number: 1, AutoMerge: true},
 	})
 

--- a/providers/ipqs/ipqs.go
+++ b/providers/ipqs/ipqs.go
@@ -26,7 +26,6 @@ const (
 	ProviderName                         = "ipqs"
 	ResultTTL                            = 1 * time.Hour
 	APIURL                               = "https://ipqualityscore.com/api/json/ip"
-	dataColumnNo                         = 2
 	veryHighScoreThreshold               = 10
 	highScoreThreshold                   = 7
 	mediumScoreThreshold                 = 5
@@ -338,7 +337,7 @@ func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
 	}
 
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 		{Number: 1, AutoMerge: true},
 	})
 

--- a/providers/ipurl/ipurl.go
+++ b/providers/ipurl/ipurl.go
@@ -24,7 +24,6 @@ const (
 	// override default set in providers package constant as column 2 is expected to be wide
 	column1MinWidth = 13
 	column2MinWidth = 10
-	dataColumnNo    = 2
 )
 
 type Config struct {
@@ -414,7 +413,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	}
 
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: column2MinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: column2MinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("IP URL | Host: %s", c.Host.String())

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "linode"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -335,7 +334,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("LINODE | Host: %s", c.Host.String())

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -23,6 +23,12 @@ const (
 	Column1MinWidth    = 14
 	WideColumnMaxWidth = 75
 	WideColumnMinWidth = 50
+	// defaults used across multiple packages
+	DataColumnNo   = 2
+	IndentSpaces   = 2
+	MaxColumnWidth = 60
+	MinColumnWidth = 20
+	MinTableWidth  = 20
 )
 
 func RowEmphasisColor(sess session.Session) func(format string, a ...interface{}) string {

--- a/providers/ptr/ptr.go
+++ b/providers/ptr/ptr.go
@@ -25,7 +25,6 @@ const (
 	portLastModifiedFormat = "2006-01-02T15:04:05+07:00"
 	ResultTTL              = 30 * time.Minute
 	DefaultNameserver      = "1.1.1.1:53"
-	dataColumnNo           = 2
 	minTableWidth          = 15
 )
 
@@ -144,7 +143,7 @@ func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
 	})
 
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: minTableWidth},
+		{Number: providers.DataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: minTableWidth},
 	})
 	tw.SetAutoIndex(false)
 	// tw.SetStyle(table.StyleColoredDark)

--- a/providers/shodan/shodan.go
+++ b/providers/shodan/shodan.go
@@ -30,8 +30,6 @@ const (
 	IndentPipeHyphens      = " |-----"
 	portLastModifiedFormat = "2006-01-02T15:04:05.999999"
 	ResultTTL              = 12 * time.Hour
-	dataColumnNo           = 2
-	indentSpaces           = 2
 	APITimeout             = 10 * time.Second
 )
 
@@ -427,12 +425,12 @@ func appendSSHRows(ssh SSH, globalIndentSpaces int, tw *table.Writer) {
 		twc.AppendRow(table.Row{
 			"",
 			fmt.Sprintf("%s%sType: %s",
-				IndentPipeHyphens, strings.Repeat(" ", indentSpaces*globalIndentSpaces), ssh.Type),
+				IndentPipeHyphens, strings.Repeat(" ", providers.IndentSpaces*globalIndentSpaces), ssh.Type),
 		})
 		twc.AppendRow(table.Row{
 			"",
 			fmt.Sprintf("%s%sCipher: %s",
-				IndentPipeHyphens, strings.Repeat(" ", indentSpaces*globalIndentSpaces), ssh.Cipher),
+				IndentPipeHyphens, strings.Repeat(" ", providers.IndentSpaces*globalIndentSpaces), ssh.Cipher),
 		})
 	}
 }
@@ -451,7 +449,7 @@ func appendHTTPRows(c *ProviderClient, http HTTP, tw *table.Writer) {
 				"",
 				fmt.Sprintf("%s%sLocation: %s",
 					IndentPipeHyphens,
-					strings.Repeat(" ", indentSpaces*c.Config.Global.IndentSpaces), http.Location),
+					strings.Repeat(" ", providers.IndentSpaces*c.Config.Global.IndentSpaces), http.Location),
 			})
 		}
 
@@ -459,14 +457,14 @@ func appendHTTPRows(c *ProviderClient, http HTTP, tw *table.Writer) {
 			"",
 			fmt.Sprintf("%s%sStatus: %d",
 				IndentPipeHyphens,
-				strings.Repeat(" ", indentSpaces*c.Config.Global.IndentSpaces), http.Status),
+				strings.Repeat(" ", providers.IndentSpaces*c.Config.Global.IndentSpaces), http.Status),
 		})
 
 		if http.Title != "" {
 			twc.AppendRow(table.Row{
 				"",
 				fmt.Sprintf("%s%sTitle: %s",
-					IndentPipeHyphens, strings.Repeat(" ", indentSpaces*c.Config.Global.IndentSpaces), http.Title),
+					IndentPipeHyphens, strings.Repeat(" ", providers.IndentSpaces*c.Config.Global.IndentSpaces), http.Title),
 			})
 		}
 
@@ -474,7 +472,7 @@ func appendHTTPRows(c *ProviderClient, http HTTP, tw *table.Writer) {
 			twc.AppendRow(table.Row{
 				"",
 				fmt.Sprintf("%s%sServer: %s",
-					IndentPipeHyphens, strings.Repeat(" ", indentSpaces*c.Config.Global.IndentSpaces), http.Server),
+					IndentPipeHyphens, strings.Repeat(" ", providers.IndentSpaces*c.Config.Global.IndentSpaces), http.Server),
 			})
 		}
 
@@ -484,7 +482,7 @@ func appendHTTPRows(c *ProviderClient, http HTTP, tw *table.Writer) {
 				"",
 				fmt.Sprintf("%s%sHTML: %s",
 					IndentPipeHyphens,
-					strings.Repeat(" ", indentSpaces*c.Config.Global.IndentSpaces),
+					strings.Repeat(" ", providers.IndentSpaces*c.Config.Global.IndentSpaces),
 					providers.PreProcessValueOutput(&c.Session, http.HTML)),
 			})
 		}
@@ -501,7 +499,7 @@ func appendDNSRows(dns DNS, globalIndentSpaces int, tw *table.Writer) {
 				"",
 				fmt.Sprintf("%s%sResolver Hostname: %s",
 					IndentPipeHyphens,
-					strings.Repeat(" ", indentSpaces*globalIndentSpaces), dns.ResolverHostname),
+					strings.Repeat(" ", providers.IndentSpaces*globalIndentSpaces), dns.ResolverHostname),
 			})
 		}
 
@@ -510,14 +508,14 @@ func appendDNSRows(dns DNS, globalIndentSpaces int, tw *table.Writer) {
 				"",
 				fmt.Sprintf("%s%sResolver Software: %s",
 					IndentPipeHyphens,
-					strings.Repeat(" ", indentSpaces*globalIndentSpaces), dns.Software),
+					strings.Repeat(" ", providers.IndentSpaces*globalIndentSpaces), dns.Software),
 			})
 		}
 
 		twc.AppendRow(table.Row{
 			"",
 			fmt.Sprintf("%s%sRecursive: %t", IndentPipeHyphens,
-				strings.Repeat(" ", indentSpaces*globalIndentSpaces), dns.Recursive),
+				strings.Repeat(" ", providers.IndentSpaces*globalIndentSpaces), dns.Recursive),
 		})
 	}
 }
@@ -530,25 +528,25 @@ func appendSSLRows(ssl Ssl, globalIndentSpaces int, rowEmphasisColor func(format
 		twc.AppendRow(table.Row{
 			"",
 			fmt.Sprintf("%s%sIssuer: %s", IndentPipeHyphens,
-				strings.Repeat(" ", indentSpaces*globalIndentSpaces), ssl.Cert.Issuer.Cn),
+				strings.Repeat(" ", providers.IndentSpaces*globalIndentSpaces), ssl.Cert.Issuer.Cn),
 		})
 		twc.AppendRow(table.Row{
 			"",
 			fmt.Sprintf("%s%sSubject: %s",
-				IndentPipeHyphens, strings.Repeat(" ", indentSpaces*globalIndentSpaces),
+				IndentPipeHyphens, strings.Repeat(" ", providers.IndentSpaces*globalIndentSpaces),
 				ssl.Cert.Subject.Cn),
 		})
 		twc.AppendRow(table.Row{
 			"",
 			fmt.Sprintf("%s%sVersions: %s",
 				IndentPipeHyphens, strings.Repeat(" ",
-					indentSpaces*globalIndentSpaces), strings.Join(ssl.Versions, ", ")),
+					providers.IndentSpaces*globalIndentSpaces), strings.Join(ssl.Versions, ", ")),
 		})
 		twc.AppendRow(table.Row{
 			"",
 			fmt.Sprintf("%s%sExpires: %s",
 				IndentPipeHyphens,
-				strings.Repeat(" ", indentSpaces*globalIndentSpaces),
+				strings.Repeat(" ", providers.IndentSpaces*globalIndentSpaces),
 				ssl.Cert.Expires),
 		})
 	}
@@ -666,7 +664,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 		tw.AppendRows(rows)
 
 		tw.SetColumnConfigs([]table.ColumnConfig{
-			{Number: dataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+			{Number: providers.DataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 		})
 	}
 

--- a/providers/virustotal/virustotal.go
+++ b/providers/virustotal/virustotal.go
@@ -29,7 +29,6 @@ const (
 	HostIPPath                           = "/api/v3/ip_addresses"
 	IndentPipeHyphens                    = " |-----"
 	ResultTTL                            = 12 * time.Hour
-	dataColumnNo                         = 2
 	veryHighScore                        = 10
 	defaultHarmlessScore                 = 0
 	defaultSuspiciousScore               = 7
@@ -609,7 +608,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	})
 
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth, ColorsHeader: text.Colors{text.BgCyan}},
+		{Number: providers.DataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth, ColorsHeader: text.Colors{text.BgCyan}},
 	})
 
 	var rows []table.Row

--- a/providers/zscaler/zscaler.go
+++ b/providers/zscaler/zscaler.go
@@ -18,7 +18,6 @@ import (
 const (
 	ProviderName = "zscaler"
 	DocTTL       = 24 * time.Hour
-	dataColumnNo = 2
 )
 
 type Config struct {
@@ -310,7 +309,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 
 	tw.AppendRows(rows)
 	tw.SetColumnConfigs([]table.ColumnConfig{
-		{Number: dataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: providers.DataColumnNo, AutoMerge: false, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
 	})
 	tw.SetAutoIndex(false)
 	tw.SetTitle("ZSCALER | Host: %s", c.Host.String())


### PR DESCRIPTION
## Summary
- centralize common constants in providers package
- add cache package message constants
- use new constants across packages
- cleanup provider implementations

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68457b90d0a483208639a38111ef93a8