### PR TITLE
Add tests for google provider

### DIFF
--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -42,11 +42,8 @@ func NewProviderClient(c session.Session) (providers.ProviderClient, error) {
 }
 
 func (c *ProviderClient) Enabled() bool {
-	if c.UseTestData || (c.Providers.Google.Enabled != nil && *c.Providers.Google.Enabled) {
-		return true
-	}
-
-	return false
+	return c.UseTestData ||
+		(c.Providers.Google.Enabled != nil && *c.Providers.Google.Enabled)
 }
 
 func (c *ProviderClient) Priority() *int32 {
@@ -89,25 +86,20 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 }
 
 func unmarshalResponse(rBody []byte) (*HostSearchResult, error) {
-	var res *HostSearchResult
-
+	var res HostSearchResult
 	if err := json.Unmarshal(rBody, &res); err != nil {
 		return nil, fmt.Errorf("error unmarshalling response: %w", err)
 	}
-
 	res.Raw = rBody
-
-	return res, nil
+	return &res, nil
 }
 
 func unmarshalProviderData(data []byte) (*google.Doc, error) {
-	var res *google.Doc
-
+	var res google.Doc
 	if err := json.Unmarshal(data, &res); err != nil {
 		return nil, fmt.Errorf("error unmarshalling google data: %w", err)
 	}
-
-	return res, nil
+	return &res, nil
 }
 
 func (c *ProviderClient) loadProviderData() error {
@@ -338,22 +330,19 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
 	}
-
 	defer jf.Close()
 
-	decoder := json.NewDecoder(jf)
-
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	var res HostSearchResult
+	if err := json.NewDecoder(jf).Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -1,0 +1,56 @@
+package google
+
+import (
+	"encoding/json"
+	"net/netip"
+	"testing"
+	"time"
+
+	fetcherGoogle "github.com/jonhadfield/ip-fetcher/providers/google"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnabled(t *testing.T) {
+	pc := &ProviderClient{}
+	enabled := true
+	pc.Providers.Google.Enabled = &enabled
+	require.True(t, pc.Enabled())
+
+	enabled = false
+	pc.UseTestData = true
+	require.True(t, pc.Enabled())
+
+	pc.UseTestData = false
+	pc.Providers.Google.Enabled = nil
+	require.False(t, pc.Enabled())
+}
+
+func TestUnmarshalResponse(t *testing.T) {
+	data := []byte(`{"prefix":"10.0.0.0/8","creation_time":"2024-05-20T10:00:00Z"}`)
+	res, err := unmarshalResponse(data)
+	require.NoError(t, err)
+	require.Equal(t, netip.MustParsePrefix("10.0.0.0/8"), res.Prefix)
+	require.Equal(t, time.Date(2024, 5, 20, 10, 0, 0, 0, time.UTC), res.CreationTime)
+	require.JSONEq(t, string(data), string(res.Raw))
+}
+
+func TestUnmarshalProviderData(t *testing.T) {
+	doc := fetcherGoogle.Doc{
+		CreationTime: time.Date(2024, 5, 20, 10, 0, 0, 0, time.UTC),
+		IPv4Prefixes: []fetcherGoogle.IPv4Entry{{IPv4Prefix: netip.MustParsePrefix("10.0.0.0/8")}},
+	}
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	res, err := unmarshalProviderData(b)
+	require.NoError(t, err)
+	require.Equal(t, doc.CreationTime, res.CreationTime)
+	require.Equal(t, doc.IPv4Prefixes[0].IPv4Prefix, res.IPv4Prefixes[0].IPv4Prefix)
+}
+
+func TestLoadResultsFile(t *testing.T) {
+	res, err := loadResultsFile("testdata/google_34_3_8_8_report.json")
+	require.NoError(t, err)
+	require.Equal(t, netip.MustParsePrefix("34.3.8.0/21"), res.Prefix)
+	require.False(t, res.CreationTime.IsZero())
+}


### PR DESCRIPTION
## Summary
- add tests for the google provider
- simplify Enabled function
- streamline unmarshalling helpers

## Testing
- `go test ./... -mod=vendor` *(fails: go.mod requires go >= 1.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_6845e744f0ec83208b4f25d406cab10a