### PR TITLE
Improve provider utilities tests and simplify helpers

### DIFF
--- a/process/process_test.go
+++ b/process/process_test.go
@@ -1,11 +1,29 @@
 package process
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jonhadfield/ipscout/providers"
 	"github.com/jonhadfield/ipscout/session"
 	"github.com/stretchr/testify/require"
 )
+
+type stubProvider struct{ enabled bool }
+
+func (s stubProvider) Enabled() bool                           { return s.enabled }
+func (stubProvider) GetConfig() *session.Session               { return nil }
+func (stubProvider) Initialise() error                         { return nil }
+func (stubProvider) FindHost() ([]byte, error)                 { return nil, nil }
+func (stubProvider) CreateTable([]byte) (*table.Writer, error) { return nil, nil }
+func (stubProvider) Priority() *int32                          { return nil }
+func (stubProvider) RateHostData([]byte, []byte) (providers.RateResult, error) {
+	return providers.RateResult{}, nil
+}
+func (stubProvider) ExtractThreatIndicators([]byte) (*providers.ThreatIndicators, error) {
+	return nil, nil
+}
 
 func TestNew(t *testing.T) {
 	t.Run("New", func(t *testing.T) {
@@ -13,4 +31,36 @@ func TestNew(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, n)
 	})
+}
+
+func TestGetEnabledProviders(t *testing.T) {
+	runners := map[string]providers.ProviderClient{
+		"a": stubProvider{enabled: true},
+		"b": stubProvider{enabled: false},
+	}
+
+	res := getEnabledProviders(runners)
+	require.Len(t, res, 1)
+	require.NotNil(t, res["a"])
+
+	res = getEnabledProviders(map[string]providers.ProviderClient{"b": stubProvider{enabled: false}})
+	require.Nil(t, res)
+}
+
+func TestGenerateJSON(t *testing.T) {
+	results := &findHostsResults{m: map[string][]byte{
+		"prov1": []byte(`{"key":"value"}`),
+	}}
+
+	jm, err := generateJSON(results)
+	require.NoError(t, err)
+
+	var out map[string]map[string]string
+	require.NoError(t, json.Unmarshal(jm, &out))
+	require.Equal(t, "value", out["prov1"]["key"])
+
+	results = &findHostsResults{m: map[string][]byte{"bad": nil}}
+	jm, err = generateJSON(results)
+	require.Error(t, err)
+	require.Nil(t, jm)
 }

--- a/providers/providers_test.go
+++ b/providers/providers_test.go
@@ -230,3 +230,57 @@ func TestIsPort(t *testing.T) {
 	require.False(t, isPort("80000"))
 	require.False(t, isPort("tcp"))
 }
+
+func TestAgeToHours(t *testing.T) {
+	h, err := AgeToHours("")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), h)
+
+	h, err = AgeToHours("2h")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), h)
+
+	h, err = AgeToHours("3d")
+	require.NoError(t, err)
+	require.Equal(t, int64(72), h)
+
+	h, err = AgeToHours("1w")
+	require.NoError(t, err)
+	require.Equal(t, int64(168), h)
+
+	h, err = AgeToHours("2m")
+	require.NoError(t, err)
+	require.Equal(t, int64(1440), h)
+
+	h, err = AgeToHours("1y")
+	require.NoError(t, err)
+	require.Equal(t, int64(8760), h)
+
+	h, err = AgeToHours("bad")
+	require.NoError(t, err)
+	require.Equal(t, int64(0), h)
+}
+
+func TestFormatTimeOrDash(t *testing.T) {
+	ts := "2024-04-19 19:00:00"
+	formatted := FormatTimeOrDash(ts, time.DateTime)
+	require.Equal(t, "2024-04-19 19:00:00 UTC", formatted)
+
+	require.Equal(t, "-", FormatTimeOrDash("", time.DateTime))
+	require.Equal(t, "-", FormatTimeOrDash(ts, ""))
+	require.Equal(t, "-", FormatTimeOrDash("bad", time.DateTime))
+}
+
+func TestPadRight(t *testing.T) {
+	require.Equal(t, "a    ", PadRight("a", 5))
+	require.Equal(t, "test", PadRight("test", 4))
+}
+
+func TestUpdateScoreIfLarger(t *testing.T) {
+	a := 1.0
+	UpdateScoreIfLarger(&a, 2)
+	require.Equal(t, 2.0, a)
+
+	UpdateScoreIfLarger(&a, 1)
+	require.Equal(t, 2.0, a)
+}

--- a/rate/rate.go
+++ b/rate/rate.go
@@ -118,16 +118,16 @@ func getEnabledProviderClients(sess session.Session) (map[string]providers.Provi
 }
 
 func getEnabledProviders(runners map[string]providers.ProviderClient) map[string]providers.ProviderClient {
-	var res map[string]providers.ProviderClient
+	res := make(map[string]providers.ProviderClient)
 
-	for k := range runners {
-		if runners[k].Enabled() {
-			if res == nil {
-				res = make(map[string]providers.ProviderClient)
-			}
-
-			res[k] = runners[k]
+	for k, r := range runners {
+		if r.Enabled() {
+			res[k] = r
 		}
+	}
+
+	if len(res) == 0 {
+		return nil
 	}
 
 	return res


### PR DESCRIPTION
## Summary
- simplify provider selection helpers
- rewrite JSON generation to use standard marshaling
- cover helper functions with new unit tests

## Testing
- `go test ./...` *(fails: go.mod requires go >= 1.24.0)*

------
https://chatgpt.com/codex/tasks/task_e_684886ccb57c8320b27bbb78d8f29d3b