### PR TITLE
Define constants for reused strings

### DIFF
--- a/providers/abuseipdb/abuseipdb.go
+++ b/providers/abuseipdb/abuseipdb.go
@@ -151,7 +151,7 @@ type Client struct {
 
 func (c *Client) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/annotated/annotated.go
+++ b/providers/annotated/annotated.go
@@ -152,15 +152,15 @@ func NewProviderClient(c session.Session) (providers.ProviderClient, error) {
 	c.Logger.Debug("creating annotated client")
 
 	if c.Logger == nil {
-		return nil, errors.New("logger not set")
+		return nil, session.ErrLoggerNotSet
 	}
 
 	if c.Stats == nil {
-		return nil, errors.New("stats not set")
+		return nil, session.ErrStatsNotSet
 	}
 
 	if c.Cache == nil {
-		return nil, errors.New("cache not set")
+		return nil, session.ErrCacheNotSet
 	}
 
 	tc := &ProviderClient{

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -155,7 +155,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -160,7 +160,7 @@ func (c *ProviderClient) loadProviderDataFromSource() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/azurewaf/azurewaf.go
+++ b/providers/azurewaf/azurewaf.go
@@ -138,7 +138,7 @@ func getPolicies(sess session.Session, azWAFSess *azwafSession.Session) ([]*armf
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/bingbot/bingbot.go
+++ b/providers/bingbot/bingbot.go
@@ -168,7 +168,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/criminalip/criminalip.go
+++ b/providers/criminalip/criminalip.go
@@ -335,7 +335,7 @@ func getDomains(domain HostSearchResultDomain) []string {
 
 func (c *Client) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -169,7 +169,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -168,7 +168,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -145,7 +145,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/googlebot/googlebot.go
+++ b/providers/googlebot/googlebot.go
@@ -168,7 +168,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/googlesc/googlesc.go
+++ b/providers/googlesc/googlesc.go
@@ -168,7 +168,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/hetzner/hetzner.go
+++ b/providers/hetzner/hetzner.go
@@ -150,7 +150,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -202,7 +202,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/ipapi/ipapi.go
+++ b/providers/ipapi/ipapi.go
@@ -126,7 +126,7 @@ func (c *Client) RateHostData(findRes []byte, ratingConfigJSON []byte) (provider
 
 func (c *Client) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/ipqs/ipqs.go
+++ b/providers/ipqs/ipqs.go
@@ -243,7 +243,7 @@ func (c *Client) RateHostData(findResJSON []byte, ratingConfigJSON []byte) (prov
 
 func (c *Client) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/ipurl/ipurl.go
+++ b/providers/ipurl/ipurl.go
@@ -157,7 +157,7 @@ type ProviderClient struct {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/linode/linode.go
+++ b/providers/linode/linode.go
@@ -168,7 +168,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/providers.go
+++ b/providers/providers.go
@@ -256,7 +256,10 @@ func splitPortTransport(portTransport string) (pt PortTransport) {
 	return pt
 }
 
-var validTransports = []string{"tcp", "udp", "icmp"}
+var (
+	validTransports = []string{"tcp", "udp", "icmp"}
+	maxPortNumber   = 65535
+)
 
 func isPort(in any) bool {
 	switch v := in.(type) {
@@ -271,11 +274,11 @@ func isPort(in any) bool {
 
 		return isPort(cint)
 	case int:
-		if v > 0 && v < 65535 {
+		if v > 0 && v < maxPortNumber {
 			return true
 		}
 	case int32:
-		if v > 0 && v < 65535 {
+		if v > 0 && v < maxPortNumber {
 			return true
 		}
 	}

--- a/providers/ptr/ptr.go
+++ b/providers/ptr/ptr.go
@@ -80,7 +80,7 @@ func (c *Client) RateHostData(findRes []byte, ratingConfigJSON []byte) (provider
 
 func (c *Client) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/shodan/shodan.go
+++ b/providers/shodan/shodan.go
@@ -353,7 +353,7 @@ func fetchData(c session.Session) (*HostSearchResult, error) {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/virustotal/virustotal.go
+++ b/providers/virustotal/virustotal.go
@@ -377,7 +377,7 @@ func fetchData(c session.Session) (*HostSearchResult, error) {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/providers/zscaler/zscaler.go
+++ b/providers/zscaler/zscaler.go
@@ -167,7 +167,7 @@ func (c *ProviderClient) loadProviderData() error {
 
 func (c *ProviderClient) Initialise() error {
 	if c.Cache == nil {
-		return errors.New("cache not set")
+		return session.ErrCacheNotSet
 	}
 
 	start := time.Now()

--- a/session/messages.go
+++ b/session/messages.go
@@ -1,0 +1,9 @@
+package session
+
+import "errors"
+
+var (
+	ErrLoggerNotSet = errors.New("logger not set")
+	ErrStatsNotSet  = errors.New("stats not set")
+	ErrCacheNotSet  = errors.New("cache not set")
+)

--- a/session/session.go
+++ b/session/session.go
@@ -83,11 +83,11 @@ func New() *Session {
 func (c *Session) Validate() error {
 	switch {
 	case c.Logger == nil:
-		return errors.New("logger not set")
+		return ErrLoggerNotSet
 	case c.Stats == nil:
-		return errors.New("stats not set")
+		return ErrStatsNotSet
 	case c.Cache == nil:
-		return errors.New("cache not set")
+		return ErrCacheNotSet
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- add session error constants
- use constants for logger/stats/cache errors
- add max port constant for `isPort`

## Testing
- `golangci-lint run --config .golangci.yml` *(fails: failed to load packages)*
- `go vet ./...` *(fails: Forbidden)*
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684886f163088320b41f3b744a1ff380