### PR TITLE
Fix loadResultsFile decoding

### DIFF
--- a/providers/bingbot/bingbot.go
+++ b/providers/bingbot/bingbot.go
@@ -355,7 +355,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -363,14 +363,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/digitalocean/digitalocean.go
+++ b/providers/digitalocean/digitalocean.go
@@ -348,7 +348,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -356,14 +356,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -368,7 +368,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -376,14 +376,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/googlebot/googlebot.go
+++ b/providers/googlebot/googlebot.go
@@ -356,7 +356,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -364,14 +364,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/googlesc/googlesc.go
+++ b/providers/googlesc/googlesc.go
@@ -356,7 +356,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -364,14 +364,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/hetzner/hetzner.go
+++ b/providers/hetzner/hetzner.go
@@ -336,7 +336,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -344,14 +344,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/icloudpr/icloudpr.go
+++ b/providers/icloudpr/icloudpr.go
@@ -402,7 +402,7 @@ func (c *ProviderClient) CreateTable(data []byte) (*table.Writer, error) {
 	return &tw, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	jf, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %w", err)
@@ -410,14 +410,14 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding file: %w", err)
 	}
 
-	return res, nil
+	return &res, nil
 }
 
 type HostSearchResult struct {

--- a/providers/virustotal/virustotal.go
+++ b/providers/virustotal/virustotal.go
@@ -271,7 +271,7 @@ func unmarshalResponse(data []byte) (*HostSearchResult, error) {
 	return &res, nil
 }
 
-func loadResultsFile(path string) (res *HostSearchResult, err error) {
+func loadResultsFile(path string) (*HostSearchResult, error) {
 	// get raw data
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -286,16 +286,16 @@ func loadResultsFile(path string) (res *HostSearchResult, err error) {
 
 	defer jf.Close()
 
+	var res HostSearchResult
 	decoder := json.NewDecoder(jf)
 
-	err = decoder.Decode(&res)
-	if err != nil {
-		return res, fmt.Errorf("error decoding virustotal file: %w", err)
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding virustotal file: %w", err)
 	}
 
 	res.Raw = raw
 
-	return res, nil
+	return &res, nil
 }
 
 func (ssr *HostSearchResult) CreateTable() *table.Writer {


### PR DESCRIPTION
## Summary
- simplify results loader functions
- avoid using pointer-to-pointer for JSON decode

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24.3)*
- `go test ./...` *(fails: go.mod requires go >= 1.24.3)*

------
https://chatgpt.com/codex/tasks/task_e_6854625d01fc8320800b51307825cc50