### PR TITLE
Refactor strings into constants

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -371,9 +371,7 @@ func initProviderConfig(sess *session.Session, v *viper.Viper) {
 	if v.IsSet("providers.hetzner.enabled") {
 		sess.Providers.Hetzner.Enabled = ToPtr(v.GetBool("providers.hetzner.enabled"))
 	} else {
-		sess.Messages.Mu.Lock()
-		sess.Messages.Info = append(sess.Messages.Info, "Hetzner provider not defined in config")
-		sess.Messages.Mu.Unlock()
+		addProviderConfigMessage(sess, "Hetzner")
 	}
 
 	if v.IsSet("providers.hetzner.output_priority") {

--- a/ui/errors.go
+++ b/ui/errors.go
@@ -10,7 +10,15 @@ import (
 
 // Error message constants
 const (
-	ErrMsgInvalidDataFormat = "Invalid data format"
+	ErrMsgInvalidDataFormat             = "Invalid data format"
+	ErrMsgNoDataFound                   = "No data found"
+	ErrMsgNoDataAvailable               = "No data available"
+	ErrMsgServiceTemporarilyUnavailable = "Service temporarily unavailable"
+	ErrMsgInvalidIPAddress              = "Invalid IP address"
+	ErrMsgConnectionFailed              = "Connection failed"
+	ErrMsgProviderNotConfigured         = "Provider not configured"
+	ErrMsgAuthenticationRequired        = "Authentication required"
+	ErrMsgServiceError                  = "Service error"
 )
 
 // Common UI error variables for simplified user messages
@@ -33,25 +41,25 @@ func simplifyError(err error, provider, _ string) string {
 	if errors.Is(err, providers.ErrNoMatchFound) ||
 		strings.Contains(errStr, "no match found") ||
 		strings.Contains(errStr, "not found") {
-		return fmt.Sprintf("%s: No data found", provider)
+		return fmt.Sprintf("%s: %s", provider, ErrMsgNoDataFound)
 	}
 
 	if errors.Is(err, providers.ErrNoDataFound) ||
 		strings.Contains(errStr, "no data found") {
-		return "No data available"
+		return ErrMsgNoDataAvailable
 	}
 
 	if errors.Is(err, providers.ErrForbiddenByProvider) ||
 		strings.Contains(errStr, "forbidden") ||
 		strings.Contains(errStr, "quota") ||
 		strings.Contains(errStr, "rate limit") {
-		return "Service temporarily unavailable"
+		return ErrMsgServiceTemporarilyUnavailable
 	}
 
 	// Check for invalid host/IP first (more specific)
 	if strings.Contains(errStr, "invalid") &&
 		(strings.Contains(errStr, "host") || strings.Contains(errStr, "ip")) {
-		return "Invalid IP address"
+		return ErrMsgInvalidIPAddress
 	}
 
 	// Check for network/connection errors
@@ -60,7 +68,7 @@ func simplifyError(err error, provider, _ string) string {
 		strings.Contains(errStr, "network") ||
 		strings.Contains(errStr, "dial") ||
 		strings.Contains(errStr, "deadline exceeded") {
-		return "Connection failed"
+		return ErrMsgConnectionFailed
 	}
 
 	// Check for parsing errors
@@ -79,14 +87,14 @@ func simplifyError(err error, provider, _ string) string {
 	if strings.Contains(errStr, "unauthorized") ||
 		strings.Contains(errStr, "authentication") ||
 		strings.Contains(errStr, "api key") {
-		return "Authentication required"
+		return ErrMsgAuthenticationRequired
 	}
 
 	// Check for provider not enabled
 	if strings.Contains(errStr, "not enabled") {
-		return "Provider not configured"
+		return ErrMsgProviderNotConfigured
 	}
 
 	// Default fallback for unknown errors
-	return "Service error"
+	return ErrMsgServiceError
 }

--- a/ui/errors_test.go
+++ b/ui/errors_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/jonhadfield/ipscout/providers"
@@ -16,47 +17,47 @@ func TestSimplifyError(t *testing.T) {
 		{
 			name:     "ErrNoMatchFound",
 			err:      providers.ErrNoMatchFound,
-			expected: "test: No data found",
+			expected: fmt.Sprintf("test: %s", ErrMsgNoDataFound),
 		},
 		{
 			name:     "ErrNoDataFound",
 			err:      providers.ErrNoDataFound,
-			expected: "No data available",
+			expected: ErrMsgNoDataAvailable,
 		},
 		{
 			name:     "ErrForbiddenByProvider",
 			err:      providers.ErrForbiddenByProvider,
-			expected: "Service temporarily unavailable",
+			expected: ErrMsgServiceTemporarilyUnavailable,
 		},
 		{
 			name:     "Complex error chain with no match found",
 			err:      errors.New("failed to find hosts: failed to find hosts: annotated match failed: no match found"),
-			expected: "test: No data found",
+			expected: fmt.Sprintf("test: %s", ErrMsgNoDataFound),
 		},
 		{
 			name:     "Complex error chain with parsing error",
 			err:      errors.New("error unmarshalling response: invalid character"),
-			expected: "Invalid data format",
+			expected: ErrMsgInvalidDataFormat,
 		},
 		{
 			name:     "Network timeout error",
 			err:      errors.New("failed to make request: context deadline exceeded (Client.Timeout exceeded)"),
-			expected: "Connection failed",
+			expected: ErrMsgConnectionFailed,
 		},
 		{
 			name:     "Invalid host error",
 			err:      errors.New("error parsing host: invalid IP address"),
-			expected: "Invalid IP address",
+			expected: ErrMsgInvalidIPAddress,
 		},
 		{
 			name:     "Provider not enabled",
 			err:      errors.New("provider shodan is not enabled"),
-			expected: "Provider not configured",
+			expected: ErrMsgProviderNotConfigured,
 		},
 		{
 			name:     "Unknown error",
 			err:      errors.New("some unknown error occurred"),
-			expected: "Service error",
+			expected: ErrMsgServiceError,
 		},
 		{
 			name:     "Nil error",

--- a/ui/main.go
+++ b/ui/main.go
@@ -98,27 +98,27 @@ func isNoDataResult(result providerResult) bool {
 	if result.table == nil {
 		text := result.text
 		// Check for exact matches
-		if text == "No data found" ||
-			text == "No data available" ||
-			text == "Service error" ||
-			text == "Connection failed" ||
+		if text == ErrMsgNoDataFound ||
+			text == ErrMsgNoDataAvailable ||
+			text == ErrMsgServiceError ||
+			text == ErrMsgConnectionFailed ||
 			text == ErrMsgInvalidDataFormat ||
-			text == "Provider not configured" ||
-			text == "Authentication required" ||
-			text == "Service temporarily unavailable" ||
-			text == "Invalid IP address" {
+			text == ErrMsgProviderNotConfigured ||
+			text == ErrMsgAuthenticationRequired ||
+			text == ErrMsgServiceTemporarilyUnavailable ||
+			text == ErrMsgInvalidIPAddress {
 			return true
 		}
 
 		// Check for provider-prefixed "no data" messages (e.g., "annotated: No data found")
-		if strings.Contains(text, ": No data found") ||
-			strings.Contains(text, ": No data available") ||
-			strings.Contains(text, ": Service error") ||
-			strings.Contains(text, ": Connection failed") ||
-			strings.Contains(text, ": Provider not configured") ||
-			strings.Contains(text, ": Authentication required") ||
-			strings.Contains(text, ": Service temporarily unavailable") ||
-			strings.Contains(text, ": Invalid IP address") {
+		if strings.Contains(text, ": "+ErrMsgNoDataFound) ||
+			strings.Contains(text, ": "+ErrMsgNoDataAvailable) ||
+			strings.Contains(text, ": "+ErrMsgServiceError) ||
+			strings.Contains(text, ": "+ErrMsgConnectionFailed) ||
+			strings.Contains(text, ": "+ErrMsgProviderNotConfigured) ||
+			strings.Contains(text, ": "+ErrMsgAuthenticationRequired) ||
+			strings.Contains(text, ": "+ErrMsgServiceTemporarilyUnavailable) ||
+			strings.Contains(text, ": "+ErrMsgInvalidIPAddress) {
 			return true
 		}
 

--- a/ui/main_test.go
+++ b/ui/main_test.go
@@ -16,14 +16,14 @@ func TestIsNoDataResult(t *testing.T) {
 		{
 			name: "Text result with no data",
 			result: providerResult{
-				text: "No data found",
+				text: ErrMsgNoDataFound,
 			},
 			expected: true,
 		},
 		{
 			name: "Provider-prefixed no data result",
 			result: providerResult{
-				text: "annotated: No data found",
+				text: "annotated: " + ErrMsgNoDataFound,
 			},
 			expected: true,
 		},

--- a/ui/root.go
+++ b/ui/root.go
@@ -221,9 +221,7 @@ func initProviderConfig(sess *session.Session, v *viper.Viper) {
 	if v.IsSet("providers.hetzner.enabled") {
 		sess.Providers.Hetzner.Enabled = ToPtr(v.GetBool("providers.hetzner.enabled"))
 	} else {
-		sess.Messages.Mu.Lock()
-		sess.Messages.Info = append(sess.Messages.Info, "Hetzner provider not defined in config")
-		sess.Messages.Mu.Unlock()
+		addProviderConfigMessage(sess, "Hetzner")
 	}
 
 	if v.IsSet("providers.hetzner.output_priority") {

--- a/ui/virustotal_test.go
+++ b/ui/virustotal_test.go
@@ -58,7 +58,7 @@ func TestCreateVirusTotalTable(t *testing.T) {
 			name: "Error result",
 			ip:   "invalid",
 			result: &virustotal.HostSearchResult{
-				Error: "Invalid IP address",
+				Error: ErrMsgInvalidIPAddress,
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- use constants instead of literals for repeated error messages
- reuse provider config helper to generate Hetzner message

## Testing
- `go test ./...` *(fails: Get https://storage.googleapis.com/... Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685c58cab3288320bf0d6ae856d67cd1