### PR TITLE
Fix log and panic issues

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -12,6 +12,8 @@ var uiCmd = &cobra.Command{
 	Long:  `Open the IPScout user interface`,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) { //nolint:revive
-		ui.OpenUI()
+		if err := ui.OpenUI(); err != nil {
+			cmd.PrintErrln(err)
+		}
 	},
 }

--- a/providers/ptr/ptr.go
+++ b/providers/ptr/ptr.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"log/slog"
 	"net/netip"
 	"os"
@@ -148,7 +147,10 @@ func FetchResponse(l *slog.Logger, host string, nameServers []string) (*HostSear
 
 	arpa, err := dns.ReverseAddr(target)
 	if err != nil {
-		log.Fatal(err)
+		if l != nil {
+			l.Error("failed to build reverse address", "error", err)
+		}
+		return nil, fmt.Errorf("reverse addr failed: %w", err)
 	}
 
 	dc := dns.Client{}

--- a/ui/main.go
+++ b/ui/main.go
@@ -249,11 +249,11 @@ func addActiveIndicatorToTable(table *tview.Table, providerName string) {
 	}
 }
 
-func OpenUI() {
+func OpenUI() error {
 	// Setup logging to app.log
 	logFile, err := os.OpenFile(LogFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, LogFilePerms)
 	if err != nil {
-		panic(fmt.Sprintf("Failed to open log file: %v", err))
+		return fmt.Errorf("failed to open log file: %w", err)
 	}
 
 	defer func() {
@@ -265,7 +265,7 @@ func OpenUI() {
 	sess, err = initConfig()
 	if err != nil {
 		slog.Error("Failed to initialise session", "error", err)
-		panic(fmt.Sprintf("Failed to initialise session: %v", err))
+		return fmt.Errorf("failed to initialise session: %w", err)
 	}
 
 	// sess.Logger.
@@ -890,8 +890,9 @@ func OpenUI() {
 
 	if err := app.SetRoot(pages, true).Run(); err != nil {
 		slog.Error("Application error", "error", err)
-		panic(err)
+		return err
 	}
 
 	slog.Info(c.AppNameSC + " " + helpers.SemVer + " shutdown complete")
+	return nil
 }


### PR DESCRIPTION
## Summary
- avoid fatal exit in PTR provider
- return error from UI helper instead of panicking
- handle UI errors in CLI command

## Testing
- `go vet ./...` *(fails: forbidden access to storage.googleapis.com)*

------
https://chatgpt.com/codex/tasks/task_e_685d87f45fb8832094cb9336812d992d