### PR TITLE
fix: resolve 4 latent provider bugs surfaced by coverage sweep

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -96,7 +96,7 @@ func (c *ProviderClient) RateHostData(findRes []byte, ratingConfigJSON []byte) (
 		return providers.RateResult{}, fmt.Errorf(constants.ErrUnmarshalFindResultFmt, err)
 	}
 
-	if doc.IPPrefix.String() == "" {
+	if !doc.IPPrefix.IsValid() && !doc.IPv6Prefix.IPv6Prefix.IsValid() {
 		return rateResult, errors.New("no prefix found in aws data")
 	}
 
@@ -219,9 +219,9 @@ func (c *ProviderClient) loadProviderDataFromCache() (*aws.Doc, error) {
 				_ = cache.Delete(c.Logger, c.Cache, cacheKey)
 			}()
 
-			return nil, fmt.Errorf("error unmarshalling cached aws provider doc: %w", err)
+			return nil, fmt.Errorf("error unmarshalling cached aws provider doc: %w", uErr)
 		}
-	} else if err != nil {
+	} else {
 		return nil, fmt.Errorf("error reading aws provider cache: %w", err)
 	}
 

--- a/providers/aws/aws_provider_test.go
+++ b/providers/aws/aws_provider_test.go
@@ -180,6 +180,16 @@ func TestRateHostDataInvalidRatingConfig(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestRateHostDataNoPrefix(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	// A result with no valid prefix should return the "no prefix found" error.
+	_, err := c.RateHostData([]byte(`{}`), []byte(`{"providers":{"aws":{"defaultMatchScore":7.5}}}`))
+	require.ErrorContains(t, err, "no prefix found")
+}
+
 func TestUnmarshalProviderData(t *testing.T) {
 	t.Parallel()
 

--- a/providers/criminalip/criminalip.go
+++ b/providers/criminalip/criminalip.go
@@ -871,11 +871,10 @@ type HostSearchResult struct {
 	IPCategory struct {
 		Count int `json:"count"`
 		Data  []struct {
-			DetectSource  string   `json:"detect_source"`
-			Type          string   `json:"type"`
-			DetectInfo    struct{} `json:"detect_info,omitempty"`
-			ConfirmedTime string   `json:"confirmed_time"`
-			DetectInfo0   struct { //nolint:govet
+			DetectSource  string `json:"detect_source"`
+			Type          string `json:"type"`
+			ConfirmedTime string `json:"confirmed_time"`
+			DetectInfo    struct {
 				Md5    string `json:"md5"`
 				Domain string `json:"domain"`
 			} `json:"detect_info,omitempty"`

--- a/providers/ipurl/ipurl_provider_test.go
+++ b/providers/ipurl/ipurl_provider_test.go
@@ -215,14 +215,19 @@ func TestFindHostNoMatch(t *testing.T) {
 }
 
 // TestFindHostUseTestData drives the UseTestData branch of FindHost. The bundled
-// fixture is a bare CIDR string (not a HostSearchResult map), so this asserts the
-// real decode-error path rather than a successful result.
+// fixture is a HostSearchResult map (prefix -> source URLs), so FindHost returns
+// it verbatim and it re-parses to include the test prefix.
 func TestFindHostUseTestData(t *testing.T) {
 	client := newTestProviderClient(t)
 	client.UseTestData = true
 
-	_, err := client.FindHost()
-	require.Error(t, err)
+	res, err := client.FindHost()
+	require.NoError(t, err)
+	require.NotEmpty(t, res)
+
+	parsed, err := unmarshalResponse(res)
+	require.NoError(t, err)
+	require.Contains(t, parsed, netip.MustParsePrefix(testPrefixCIDR))
 }
 
 func TestUnmarshalResponse(t *testing.T) {

--- a/providers/ipurl/testdata/ipurl_5_105_62_60_report.json
+++ b/providers/ipurl/testdata/ipurl_5_105_62_60_report.json
@@ -1,1 +1,5 @@
-"5.105.62.0/24"
+{
+  "5.105.62.0/24": [
+    "https://example.com/blocklist.txt"
+  ]
+}

--- a/providers/zscaler/testdata/zscaler_doc.json
+++ b/providers/zscaler/testdata/zscaler_doc.json
@@ -1,0 +1,98 @@
+{
+  "zscaler.net": {
+    "continent : EMEA": {
+      "city : Abu Dhabi II": [
+        {
+          "range": "147.161.174.0/23",
+          "vpn": "",
+          "gre": "",
+          "hostname": "",
+          "latitude": "24.453884",
+          "longitude": "54.377344"
+        }
+      ],
+      "city : Amsterdam II": [
+        {
+          "range": "147.161.172.0/23",
+          "vpn": "",
+          "gre": "165.225.240.12",
+          "hostname": "",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "165.225.240.0/23",
+          "vpn": "ams2-2-vpn.zscaler.net",
+          "gre": "165.225.240.12",
+          "hostname": "ams2-2.sme.zscaler.net",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "170.85.78.0/23",
+          "vpn": "",
+          "gre": "185.46.212.32",
+          "hostname": "",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "136.226.200.0/23",
+          "vpn": "",
+          "gre": "",
+          "hostname": "",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "2a03:eec0:321d::/48",
+          "vpn": "",
+          "gre": "165.225.240.12",
+          "hostname": "",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "136.226.202.0/23",
+          "vpn": "",
+          "gre": "",
+          "hostname": "",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "136.226.204.0/23",
+          "vpn": "",
+          "gre": "",
+          "hostname": "",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "147.161.156.0/23",
+          "vpn": "",
+          "gre": "185.46.212.32",
+          "hostname": "",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "147.161.132.0/23",
+          "vpn": "",
+          "gre": "185.46.212.32",
+          "hostname": "",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        },
+        {
+          "range": "185.46.212.0/23",
+          "vpn": "amsterdam2-vpn.zscaler.net",
+          "gre": "185.46.212.32",
+          "hostname": "ams2.sme.zscaler.net",
+          "latitude": "52.367573",
+          "longitude": "4.904139"
+        }
+      ]
+    }
+  }
+}

--- a/providers/zscaler/testdata/zscaler_report.json
+++ b/providers/zscaler/testdata/zscaler_report.json
@@ -1,98 +1,10 @@
 {
-  "zscaler.net": {
-    "continent : EMEA": {
-      "city : Abu Dhabi II": [
-        {
-          "range": "147.161.174.0/23",
-          "vpn": "",
-          "gre": "",
-          "hostname": "",
-          "latitude": "24.453884",
-          "longitude": "54.377344"
-        }
-      ],
-      "city : Amsterdam II": [
-        {
-          "range": "147.161.172.0/23",
-          "vpn": "",
-          "gre": "165.225.240.12",
-          "hostname": "",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "165.225.240.0/23",
-          "vpn": "ams2-2-vpn.zscaler.net",
-          "gre": "165.225.240.12",
-          "hostname": "ams2-2.sme.zscaler.net",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "170.85.78.0/23",
-          "vpn": "",
-          "gre": "185.46.212.32",
-          "hostname": "",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "136.226.200.0/23",
-          "vpn": "",
-          "gre": "",
-          "hostname": "",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "2a03:eec0:321d::/48",
-          "vpn": "",
-          "gre": "165.225.240.12",
-          "hostname": "",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "136.226.202.0/23",
-          "vpn": "",
-          "gre": "",
-          "hostname": "",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "136.226.204.0/23",
-          "vpn": "",
-          "gre": "",
-          "hostname": "",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "147.161.156.0/23",
-          "vpn": "",
-          "gre": "185.46.212.32",
-          "hostname": "",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "147.161.132.0/23",
-          "vpn": "",
-          "gre": "185.46.212.32",
-          "hostname": "",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        },
-        {
-          "range": "185.46.212.0/23",
-          "vpn": "amsterdam2-vpn.zscaler.net",
-          "gre": "185.46.212.32",
-          "hostname": "ams2.sme.zscaler.net",
-          "latitude": "52.367573",
-          "longitude": "4.904139"
-        }
-      ]
-    }
-  }
+  "continent": "EMEA",
+  "city": "Amsterdam II",
+  "vpn": "ams2-2-vpn.zscalerthree.net",
+  "range": "165.225.240.0/23",
+  "gre": "165.225.240.12",
+  "hostname": "",
+  "latitude": "52.367573",
+  "longitude": "4.904139"
 }

--- a/providers/zscaler/zscaler_provider_test.go
+++ b/providers/zscaler/zscaler_provider_test.go
@@ -149,19 +149,22 @@ func TestFindHostUsesTestData(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, res)
 
-	// The bytes returned should re-parse as a HostSearchResult.
+	// The bytes returned should re-parse as a populated HostSearchResult
+	// matching the flat test-data fixture.
 	parsed, err := unmarshalResponse(res)
 	require.NoError(t, err)
 	require.NotNil(t, parsed)
+	require.Equal(t, "165.225.240.0/23", parsed.Range)
+	require.Equal(t, "Amsterdam II", parsed.City)
 }
 
-// seedProviderDoc loads the testdata fixture (which is in ipfetcher.Doc format),
+// seedProviderDoc loads the nested upstream fixture (ipfetcher.Doc format),
 // marshals it, and stores it in the cache exactly as loadProviderData would, so
 // the real cache-backed FindHost reflection path can be exercised offline.
 func seedProviderDoc(t *testing.T, c *ProviderClient) {
 	t.Helper()
 
-	raw, err := providers.LoadResultsFile[ipfetcher.Doc]("testdata/zscaler_report.json")
+	raw, err := providers.LoadResultsFile[ipfetcher.Doc]("testdata/zscaler_doc.json")
 	require.NoError(t, err)
 
 	data, err := json.Marshal(raw)


### PR DESCRIPTION
Follow-up to #96. Fixes the four latent bugs the coverage sweep surfaced — the new tests previously asserted the *buggy* behavior; they now assert correct behavior.

## Fixes

- **aws — `loadProviderDataFromCache`**: wrapped the wrong error variable (nil `err` instead of `uErr`), and had a tautological `else if err != nil` (always true inside the `err == nil` else branch). Simplified to `else`. *(this was the `go vet` nilness diagnostic)*
- **aws — `RateHostData`**: guarded `doc.IPPrefix.String() == ""`, which never fires (a zero `netip.Prefix` stringifies to `"invalid Prefix"`). Replaced with an `IsValid()` check so the "no prefix found" branch is reachable; added `TestRateHostDataNoPrefix`.
- **criminalip**: two struct fields shared the json tag `detect_info`, so neither populated reliably (and tripped the `structtag` vet check). Merged into a single `DetectInfo{Md5,Domain}` field.
- **zscaler**: `testdata/zscaler_report.json` was the nested upstream `Doc` format, but `loadTestData` decodes a flat `HostSearchResult`, so `--use-test-data` silently returned an **empty** result. Replaced with a flat fixture; moved the nested fixture to `zscaler_doc.json` for the cache-seeding test and tightened the UseTestData assertion.
- **ipurl**: the testdata fixture was a bare CIDR string, but `HostSearchResult` is `map[netip.Prefix][]string`, so `--use-test-data` **errored** on decode. Replaced with a correctly shaped map and updated the test.

The zscaler and ipurl fixes mean `--use-test-data` actually works for those two providers now.

## Verification

- [x] `go vet ./providers/aws/ ./providers/criminalip/` — clean (both prior diagnostics gone)
- [x] full suite passes (`go test -p 1 ./...`)
- [x] `golangci-lint run ./...` → 0 issues
- [x] total coverage 36.6% → 37.0% (coverage gate floor 35% still satisfied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)