### PR TITLE
test: add coverage for core packages + raise gate to 45%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         # coverage improves so it can only move up. Linux-only to avoid duplication.
         if: runner.os == 'Linux'
         env:
-          MIN_COVERAGE: "35.0"
+          MIN_COVERAGE: "45.0"
         run: |
           total=$(go tool cover -func=cover.out | awk '/^total:/ {gsub(/%/,"",$3); print $3}')
           echo "total coverage: ${total}% (minimum: ${MIN_COVERAGE}%)"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ cover: test
 
 # Ratchet gate: fail if total statement coverage drops below MIN_COVERAGE.
 # Raise MIN_COVERAGE as coverage improves so it can only move up.
-MIN_COVERAGE?=35.0
+MIN_COVERAGE?=45.0
 cover-check:
 	@total=$$(go tool cover -func=coverage.txt | awk '/^total:/ {gsub(/%/,"",$$3); print $$3}'); \
 	echo "total coverage: $$total% (minimum: $(MIN_COVERAGE)%)"; \

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,0 +1,511 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	c "github.com/jonhadfield/ipscout/constants"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testOutputPriority int32 = 99
+	testCacheTTL       int64 = 1234
+)
+
+const (
+	cmdConfig  = "config"
+	cmdGet     = "get"
+	cmdDefault = "default"
+	cmdRate    = "rate"
+	cmdVersion = "Version"
+	hostA      = "1.1.1.1"
+	hostB      = "8.8.8.8"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+}
+
+func TestToPtr(t *testing.T) {
+	t.Parallel()
+
+	v := 42
+	p := ToPtr(v)
+	require.NotNil(t, p)
+	assert.Equal(t, v, *p)
+
+	s := ToPtr("hello")
+	require.NotNil(t, s)
+	assert.Equal(t, "hello", *s)
+
+	b := ToPtr(true)
+	require.NotNil(t, b)
+	assert.True(t, *b)
+}
+
+func TestNewRootCommand(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := newRootCommand()
+	require.NotNil(t, rootCmd)
+	assert.Equal(t, "ipscout [options] <host>", rootCmd.Use)
+	assert.True(t, rootCmd.SilenceErrors)
+	assert.True(t, rootCmd.SilenceUsage)
+
+	wantSubcommands := []string{"cache", cmdConfig, cmdRate, cmdVersion, "ui"}
+	for _, name := range wantSubcommands {
+		_, _, err := rootCmd.Find([]string{name})
+		require.NoErrorf(t, err, "expected subcommand %q", name)
+	}
+
+	wantFlags := []string{
+		"log-level", "output", "style", "max-age", "max-reports",
+		"use-test-data", "disable-cache", "ports", "max-value-chars",
+		"filter-providers", "file",
+	}
+	for _, name := range wantFlags {
+		assert.NotNilf(t, rootCmd.PersistentFlags().Lookup(name), "expected persistent flag %q", name)
+	}
+}
+
+func TestNewCacheCommand(t *testing.T) {
+	t.Parallel()
+
+	cacheCmd := newCacheCommand()
+	require.NotNil(t, cacheCmd)
+	assert.Equal(t, "cache", cacheCmd.Use)
+
+	wantSub := []string{"list", "init", cmdGet, "delete"}
+	for _, name := range wantSub {
+		_, _, err := cacheCmd.Find([]string{name})
+		require.NoErrorf(t, err, "expected cache subcommand %q", name)
+	}
+
+	getCmd, _, err := cacheCmd.Find([]string{cmdGet})
+	require.NoError(t, err)
+	assert.NotNil(t, getCmd.PersistentFlags().Lookup("raw"))
+}
+
+func TestNewConfigCommand(t *testing.T) {
+	t.Parallel()
+
+	configCmd := newConfigCommand()
+	require.NotNil(t, configCmd)
+	assert.Equal(t, cmdConfig, configCmd.Use)
+
+	for _, name := range []string{"show", cmdDefault} {
+		_, _, err := configCmd.Find([]string{name})
+		require.NoErrorf(t, err, "expected config subcommand %q", name)
+	}
+}
+
+func TestNewRateCommand(t *testing.T) {
+	t.Parallel()
+
+	rateCmd := newRateCommand()
+	require.NotNil(t, rateCmd)
+	assert.Equal(t, cmdRate, rateCmd.Use)
+	assert.NotNil(t, rateCmd.PersistentFlags().Lookup("ai"))
+	assert.NotNil(t, rateCmd.PersistentFlags().Lookup("openai-api-key"))
+
+	cfgCmd, _, err := rateCmd.Find([]string{cmdConfig})
+	require.NoError(t, err)
+	assert.NotNil(t, cfgCmd.Flags().Lookup(cmdDefault))
+	assert.NotNil(t, cfgCmd.Flags().Lookup("path"))
+}
+
+func TestVersionCmd(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, cmdVersion, versionCmd.Use)
+
+	var buf bytes.Buffer
+
+	versionCmd.SetOut(&buf)
+	versionCmd.SetErr(&buf)
+	versionCmd.Run(versionCmd, nil)
+	// version output goes to stdout via fmt.Println; ensure the command does not panic
+	assert.NotNil(t, versionCmd.Run)
+}
+
+func TestUICmd(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "ui", uiCmd.Use)
+	assert.NotNil(t, uiCmd.Run)
+}
+
+func TestReadHostsFromReader(t *testing.T) {
+	t.Parallel()
+
+	input := hostA + "\n\n# comment\n  " + hostB + "  \nexample.com\n"
+	scanner := bufio.NewScanner(strings.NewReader(input))
+
+	hosts, err := readHostsFromReader(scanner)
+	require.NoError(t, err)
+	assert.Equal(t, []string{hostA, hostB, "example.com"}, hosts)
+}
+
+func TestReadHostsFromReaderEmpty(t *testing.T) {
+	t.Parallel()
+
+	scanner := bufio.NewScanner(strings.NewReader("\n#only comments\n"))
+
+	hosts, err := readHostsFromReader(scanner)
+	require.NoError(t, err)
+	assert.Empty(t, hosts)
+}
+
+func TestReadHostsFromFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hosts.txt")
+	require.NoError(t, os.WriteFile(path, []byte("9.9.9.9\n# skip\n1.0.0.1\n"), 0o600))
+
+	hosts, err := readHostsFromFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"9.9.9.9", "1.0.0.1"}, hosts)
+}
+
+func TestReadHostsFromFileMissing(t *testing.T) {
+	t.Parallel()
+
+	_, err := readHostsFromFile(filepath.Join(t.TempDir(), "does-not-exist.txt"))
+	require.Error(t, err)
+}
+
+func TestCollectHostsFromArgs(t *testing.T) {
+	t.Parallel()
+
+	cmd := newRootCommand()
+
+	hosts, err := collectHosts(cmd, []string{hostA, hostB})
+	require.NoError(t, err)
+	assert.Equal(t, []string{hostA, hostB}, hosts)
+}
+
+func TestCollectHostsFromFileFlag(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hosts.txt")
+	require.NoError(t, os.WriteFile(path, []byte("2.2.2.2\n3.3.3.3\n"), 0o600))
+
+	cmd := newRootCommand()
+	// merge persistent flags into the local flag set that collectHosts reads.
+	cmd.InheritedFlags()
+	require.NoError(t, cmd.Flags().Set("file", path))
+
+	hosts, err := collectHosts(cmd, nil)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"2.2.2.2", "3.3.3.3"}, hosts)
+}
+
+func TestAddProviderConfigMessage(t *testing.T) {
+	t.Parallel()
+
+	s := session.New()
+	addProviderConfigMessage(s, "TestProvider")
+	require.Len(t, s.Messages.Info, 1)
+	assert.Contains(t, s.Messages.Info[0], "TestProvider")
+}
+
+func TestSetProviderAPIKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("key from viper enables", func(t *testing.T) {
+		t.Parallel()
+
+		v := viper.New()
+		v.Set("test_api_key", "secret")
+
+		apiKey := ""
+		enabled := ToPtr(true)
+		setProviderAPIKey(v, "test_api_key", &apiKey, &enabled)
+		assert.Equal(t, "secret", apiKey)
+		require.NotNil(t, enabled)
+		assert.True(t, *enabled)
+	})
+
+	t.Run("missing key disables", func(t *testing.T) {
+		t.Parallel()
+
+		v := viper.New()
+
+		apiKey := ""
+		enabled := ToPtr(true)
+		setProviderAPIKey(v, "absent_api_key", &apiKey, &enabled)
+		assert.Empty(t, apiKey)
+		require.NotNil(t, enabled)
+		assert.False(t, *enabled)
+	})
+}
+
+func TestBindFlags(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{Use: "test"}
+
+	var value string
+
+	cmd.Flags().StringVar(&value, "output", "table", "output")
+
+	v := viper.New()
+	// bindFlags overwrites viper with the current (unchanged) flag value, so it is
+	// effectively a no-op for unchanged flags. Verify it runs without panicking and
+	// leaves the flag at its default.
+	bindFlags(cmd, v)
+
+	got, err := cmd.Flags().GetString("output")
+	require.NoError(t, err)
+	assert.Equal(t, "table", got)
+
+	// when a flag is explicitly changed, bindFlags must not clobber it.
+	require.NoError(t, cmd.Flags().Set("output", "csv"))
+	bindFlags(cmd, v)
+
+	got, err = cmd.Flags().GetString("output")
+	require.NoError(t, err)
+	assert.Equal(t, "csv", got)
+}
+
+func TestInitProviderConfig(t *testing.T) {
+	t.Parallel()
+
+	s := session.New()
+	v := viper.New()
+
+	v.Set("providers.abuseipdb.enabled", true)
+	v.Set("providers.abuseipdb.output_priority", int(testOutputPriority))
+	v.Set("providers.shodan.result_cache_ttl", int(testCacheTTL))
+
+	initProviderConfig(s, v)
+
+	require.NotNil(t, s.Providers.AbuseIPDB.Enabled)
+	assert.True(t, *s.Providers.AbuseIPDB.Enabled)
+	require.NotNil(t, s.Providers.AbuseIPDB.OutputPriority)
+	assert.Equal(t, testOutputPriority, *s.Providers.AbuseIPDB.OutputPriority)
+	assert.Equal(t, testCacheTTL, s.Providers.Shodan.ResultCacheTTL)
+
+	// providers not set should fall back to default priority and emit info messages
+	require.NotNil(t, s.Providers.Alibaba.OutputPriority)
+	assert.Equal(t, int32(defaultAlibabaOutputPriority), *s.Providers.Alibaba.OutputPriority)
+	assert.NotEmpty(t, s.Messages.Info)
+}
+
+func TestInitSessionConfig(t *testing.T) {
+	t.Parallel()
+
+	s := session.New()
+	v := viper.New()
+
+	v.Set("global.max_age", "30d")
+	v.Set("global.max_reports", session.DefaultMaxReports)
+	v.Set("rating.use_ai", true)
+	v.Set("rating.openai_api_key", "key")
+
+	require.NoError(t, initSessionConfig(s, v))
+	assert.Equal(t, "30d", s.Config.Global.MaxAge)
+	assert.Equal(t, session.DefaultMaxReports, s.Config.Global.MaxReports)
+	assert.True(t, s.Config.Rating.UseAI)
+	assert.Equal(t, "key", s.Config.Rating.OpenAIAPIKey)
+}
+
+func TestInitSessionConfigPortsSentinel(t *testing.T) {
+	t.Parallel()
+
+	s := session.New()
+	v := viper.New()
+	v.Set("global.ports", []string{"[]"})
+
+	require.NoError(t, initSessionConfig(s, v))
+	assert.Nil(t, s.Config.Global.Ports)
+}
+
+func TestInitHomeDirConfigFromViper(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	s := session.New()
+	v := viper.New()
+	v.Set("home_dir", dir)
+
+	require.NoError(t, initHomeDirConfig(s, v))
+	assert.Equal(t, dir, s.Config.Global.HomeDir)
+}
+
+func TestInitHomeDirConfigMissing(t *testing.T) {
+	t.Parallel()
+
+	s := session.New()
+	v := viper.New()
+	v.Set("home_dir", filepath.Join(t.TempDir(), "missing-subdir"))
+
+	err := initHomeDirConfig(s, v)
+	require.Error(t, err)
+}
+
+func TestInitLogging(t *testing.T) {
+	t.Parallel()
+
+	levels := map[string]bool{
+		"ERROR": false,
+		"WARN":  false,
+		"INFO":  true,
+		"DEBUG": true,
+	}
+
+	for level, hideProgress := range levels {
+		s := session.New()
+		s.Target = os.Stderr
+
+		// initLogging reads the package-level sess via assignment of fields on the passed session
+		// Build a command carrying the log-level flag.
+		cmd := &cobra.Command{Use: "test"}
+
+		var ll string
+
+		cmd.Flags().StringVar(&ll, "log-level", level, "log level")
+
+		// initLogging operates on the package level sess variable.
+		sess = s
+
+		require.NoError(t, initLogging(cmd))
+		assert.Equal(t, level, sess.Config.Global.LogLevel)
+		assert.Equal(t, hideProgress, sess.HideProgress)
+		require.NotNil(t, sess.Logger)
+	}
+}
+
+// withSandboxHome points HOME at a temp dir so initConfig never touches the
+// real user config and never hits the network.
+func withSandboxHome(t *testing.T) {
+	t.Helper()
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // windows
+}
+
+func TestInitConfigSandboxed(t *testing.T) {
+	withSandboxHome(t)
+
+	cmd := newRootCommand()
+	// ParseFlags merges the persistent flag set into cmd.Flags(), which initConfig reads.
+	require.NoError(t, cmd.ParseFlags(nil))
+	require.NoError(t, initConfig(cmd))
+	require.NotNil(t, sess)
+	require.NotNil(t, sess.Logger)
+	assert.Equal(t, c.DefaultIndentSpaces, sess.Config.Global.IndentSpaces)
+
+	// default config should have been written under the sandbox home
+	home, err := os.UserHomeDir()
+	require.NoError(t, err)
+
+	cfgPath := filepath.Join(home, ".config", AppName, "config.yaml")
+	_, statErr := os.Stat(cfgPath)
+	require.NoError(t, statErr)
+}
+
+func TestConfigDefaultCommandOffline(t *testing.T) {
+	withSandboxHome(t)
+
+	rootCmd := newRootCommand()
+
+	var out bytes.Buffer
+
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{cmdConfig, cmdDefault})
+
+	require.NoError(t, rootCmd.Execute())
+}
+
+func TestRateConfigCommandResolves(t *testing.T) {
+	t.Parallel()
+
+	// The `rate config` RunE calls os.Exit() on every branch, so it cannot be
+	// executed in-process. Verify the command resolves and its flags are wired.
+	rootCmd := newRootCommand()
+
+	cfgCmd, _, err := rootCmd.Find([]string{cmdRate, cmdConfig})
+	require.NoError(t, err)
+	assert.NotNil(t, cfgCmd.Flags().Lookup(cmdDefault))
+	assert.NotNil(t, cfgCmd.Flags().Lookup("path"))
+}
+
+func TestRootHelpOffline(t *testing.T) {
+	withSandboxHome(t)
+
+	rootCmd := newRootCommand()
+
+	var out bytes.Buffer
+
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--help"})
+
+	require.NoError(t, rootCmd.Execute())
+	assert.Contains(t, out.String(), "IPScout")
+}
+
+func TestFlagErrorFunc(t *testing.T) {
+	withSandboxHome(t)
+
+	rootCmd := newRootCommand()
+
+	var out bytes.Buffer
+
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--nonexistent-flag"})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+}
+
+func TestExecuteVersionOffline(t *testing.T) {
+	// Execute() reads the real os.Args and builds its own root command. Drive it
+	// through the Version subcommand, which only prints and performs no network I/O.
+	withSandboxHome(t)
+
+	origArgs := os.Args
+
+	t.Cleanup(func() { os.Args = origArgs })
+
+	os.Args = []string{AppName, cmdVersion}
+
+	require.NoError(t, Execute())
+}
+
+func TestVisitAllPersistentFlags(t *testing.T) {
+	t.Parallel()
+
+	rootCmd := newRootCommand()
+
+	count := 0
+
+	rootCmd.PersistentFlags().VisitAll(func(_ *pflag.Flag) {
+		count++
+	})
+	assert.Positive(t, count)
+}
+
+func TestDiscardLoggerHelper(t *testing.T) {
+	t.Parallel()
+
+	require.NotNil(t, discardLogger())
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,270 @@
+package config
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jonhadfield/ipscout/cache"
+	"github.com/jonhadfield/ipscout/providers"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testIndentSpaces  = 2
+	testMaxValueChars = 100
+	testMaxReports    = 5
+)
+
+// newTestSession builds a session backed by a temporary BadgerDB cache so the
+// config client logic runs without touching real $HOME config or the network.
+func newTestSession(t *testing.T) *session.Session {
+	t.Helper()
+
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+
+	homeDir := t.TempDir()
+
+	db, err := cache.Create(lg, filepath.Join(homeDir, ".config", "ipscout"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	sess := &session.Session{
+		Logger: lg,
+		Stats:  session.CreateStats(),
+		Cache:  db,
+	}
+
+	sess.Config.Global.HomeDir = homeDir
+	sess.Config.Global.IndentSpaces = testIndentSpaces
+	sess.Config.Global.MaxValueChars = testMaxValueChars
+	sess.Config.Global.MaxAge = "90d"
+	sess.Config.Global.MaxReports = testMaxReports
+	sess.Config.Rating.ConfigPath = "/some/path"
+	sess.Config.Rating.UseAI = true
+
+	enabled := true
+	disabled := false
+	sess.Providers.AbuseIPDB.Enabled = &enabled
+	sess.Providers.Annotated.Enabled = &enabled
+	sess.Providers.Annotated.Paths = []string{"/a/path", "/b/path"}
+	sess.Providers.IPURL.Enabled = &disabled
+	sess.Providers.IPURL.URLs = []string{"https://example.com/list"}
+
+	return sess
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	sess := &session.Session{}
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+	require.Same(t, sess, c.Sess)
+}
+
+func TestCreateConfigTable(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	c := &Client{Sess: sess}
+
+	tw, err := c.CreateConfigTable()
+	require.NoError(t, err)
+	require.NotNil(t, tw)
+
+	rendered := (*tw).Render()
+	require.NotEmpty(t, rendered)
+	require.Contains(t, rendered, "CONFIG")
+	require.Contains(t, rendered, "Global")
+	require.Contains(t, rendered, "Providers")
+	require.Contains(t, rendered, "AbuseIPDB")
+}
+
+func TestCreateConfigTableOpenAIKeyDefined(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+	sess.Config.Rating.OpenAIAPIKey = "sk-test"
+
+	c := &Client{Sess: sess}
+
+	tw, err := c.CreateConfigTable()
+	require.NoError(t, err)
+
+	rendered := (*tw).Render()
+	require.Contains(t, rendered, "<defined>")
+	require.NotContains(t, rendered, "<not defined>")
+}
+
+func TestCreateConfigTableOpenAIKeyUndefined(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	c := &Client{Sess: sess}
+
+	tw, err := c.CreateConfigTable()
+	require.NoError(t, err)
+
+	rendered := (*tw).Render()
+	require.Contains(t, rendered, "<not defined>")
+}
+
+func TestShow(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	c := &Client{Sess: sess}
+
+	require.NoError(t, c.Show())
+}
+
+func TestGetCacheItemsInfoEmpty(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	c := &Client{Sess: sess}
+
+	items, err := c.GetCacheItemsInfo()
+	require.NoError(t, err)
+	require.Empty(t, items)
+}
+
+func TestGetCacheItemsInfoWithItems(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	key := providers.CacheProviderPrefix + "shodan_8.8.8.8"
+
+	err := cache.UpsertWithTTL(sess.Logger, sess.Cache, cache.Item{
+		Key:        key,
+		Value:      []byte(`{"data":"test"}`),
+		AppVersion: "1.2.3",
+		Created:    time.Now(),
+	}, time.Hour)
+	require.NoError(t, err)
+
+	c := &Client{Sess: sess}
+
+	items, err := c.GetCacheItemsInfo()
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	require.Equal(t, key, items[0].Key)
+	require.Equal(t, "1.2.3", items[0].AppVersion)
+}
+
+func TestGetCacheItemsInfoIgnoresNonProviderKeys(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	err := cache.UpsertWithTTL(sess.Logger, sess.Cache, cache.Item{
+		Key:     "metadata_other",
+		Value:   []byte(`{"data":"test"}`),
+		Created: time.Now(),
+	}, time.Hour)
+	require.NoError(t, err)
+
+	c := &Client{Sess: sess}
+
+	items, err := c.GetCacheItemsInfo()
+	require.NoError(t, err)
+	require.Empty(t, items)
+}
+
+// newOnDiskSession builds a session whose HomeDir contains a pre-populated,
+// closed on-disk cache. Get/Delete re-open that cache themselves, so the session
+// must not hold the directory lock. Returns the session and the cache key seeded.
+func newOnDiskSession(t *testing.T, seed *cache.Item) *session.Session {
+	t.Helper()
+
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+
+	homeDir := t.TempDir()
+
+	sess := &session.Session{
+		Logger: lg,
+		Stats:  session.CreateStats(),
+	}
+	sess.Config.Global.HomeDir = homeDir
+
+	if seed != nil {
+		db, err := cache.Create(lg, filepath.Join(homeDir, ".config", "ipscout"))
+		require.NoError(t, err)
+		require.NoError(t, cache.UpsertWithTTL(lg, db, *seed, time.Hour))
+		require.NoError(t, db.Close())
+	}
+
+	return sess
+}
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+
+	key := "testkey"
+
+	sess := newOnDiskSession(t, &cache.Item{
+		Key:        key,
+		Value:      []byte(`{"hello":"world"}`),
+		AppVersion: "1.0.0",
+		Version:    "v1",
+		Created:    time.Now(),
+	})
+
+	c := &Client{Sess: sess}
+
+	// Get opens, uses, and defer-closes its own cache handle internally.
+	require.NoError(t, c.Get(key, false))
+}
+
+func TestGetRaw(t *testing.T) {
+	t.Parallel()
+
+	key := "rawkey"
+
+	sess := newOnDiskSession(t, &cache.Item{
+		Key:     key,
+		Value:   []byte(`{"raw":true}`),
+		Created: time.Now(),
+	})
+
+	c := &Client{Sess: sess}
+
+	require.NoError(t, c.Get(key, true))
+}
+
+func TestGetMissingKey(t *testing.T) {
+	t.Parallel()
+
+	sess := newOnDiskSession(t, nil)
+
+	c := &Client{Sess: sess}
+
+	err := c.Get("does-not-exist", false)
+	require.Error(t, err)
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	key := "delkey"
+
+	sess := newOnDiskSession(t, &cache.Item{
+		Key:     key,
+		Value:   []byte(`{"del":true}`),
+		Created: time.Now(),
+	})
+
+	c := &Client{Sess: sess}
+
+	require.NoError(t, c.Delete([]string{key}))
+}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -1,0 +1,129 @@
+package helpers
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testProvider = "testprovider"
+	trackSleep   = 5 * time.Millisecond
+)
+
+func TestParseHostIPv4(t *testing.T) {
+	t.Parallel()
+
+	addr, err := ParseHost("8.8.8.8")
+	require.NoError(t, err)
+	require.True(t, addr.Is4())
+	require.Equal(t, "8.8.8.8", addr.String())
+}
+
+func TestParseHostIPv6(t *testing.T) {
+	t.Parallel()
+
+	addr, err := ParseHost("2001:4860:4860::8888")
+	require.NoError(t, err)
+	require.True(t, addr.Is6())
+	require.Equal(t, "2001:4860:4860::8888", addr.String())
+}
+
+func TestParseHostSingleHostCIDR(t *testing.T) {
+	t.Parallel()
+
+	addr, err := ParseHost("1.2.3.4/32")
+	require.NoError(t, err)
+	require.Equal(t, "1.2.3.4", addr.String())
+}
+
+func TestParseHostLoopbackFQDN(t *testing.T) {
+	t.Parallel()
+
+	addr, err := ParseHost("localhost")
+	require.NoError(t, err)
+	require.True(t, addr.IsLoopback())
+}
+
+func TestParseHostInvalid(t *testing.T) {
+	t.Parallel()
+
+	addr, err := ParseHost("this.is.not.a.valid.host.invalid")
+	require.Error(t, err)
+	require.False(t, addr.IsValid())
+}
+
+func TestGetHTTPClient(t *testing.T) {
+	t.Parallel()
+
+	hc := GetHTTPClient()
+	require.NotNil(t, hc)
+	require.NotNil(t, hc.HTTPClient)
+}
+
+func TestTrackDuration(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+
+	durations := make(map[string]time.Duration)
+
+	done := TrackDuration(&mu, durations, testProvider)
+
+	time.Sleep(trackSleep)
+	done()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	d, ok := durations[testProvider]
+	require.True(t, ok)
+	require.Positive(t, d)
+}
+
+func TestFindProjectRoot(t *testing.T) {
+	t.Parallel()
+
+	root, err := FindProjectRoot()
+	require.NoError(t, err)
+	require.NotEmpty(t, root)
+
+	_, statErr := os.Stat(filepath.Join(root, "go.mod"))
+	require.NoError(t, statErr)
+}
+
+func TestPrefixProjectRootEmpty(t *testing.T) {
+	t.Parallel()
+
+	root, err := FindProjectRoot()
+	require.NoError(t, err)
+
+	prefixed, err := PrefixProjectRoot("")
+	require.NoError(t, err)
+	require.Equal(t, root, prefixed)
+}
+
+func TestPrefixProjectRootRelative(t *testing.T) {
+	t.Parallel()
+
+	root, err := FindProjectRoot()
+	require.NoError(t, err)
+
+	prefixed, err := PrefixProjectRoot("helpers")
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(root, "helpers"), prefixed)
+}
+
+func TestPrefixProjectRootAbsolute(t *testing.T) {
+	t.Parallel()
+
+	abs := filepath.Join(string(filepath.Separator), "tmp", "ipscout-abs")
+
+	prefixed, err := PrefixProjectRoot(abs)
+	require.NoError(t, err)
+	require.Equal(t, abs, prefixed)
+}

--- a/helpers/helpers_test.go
+++ b/helpers/helpers_test.go
@@ -121,7 +121,9 @@ func TestPrefixProjectRootRelative(t *testing.T) {
 func TestPrefixProjectRootAbsolute(t *testing.T) {
 	t.Parallel()
 
-	abs := filepath.Join(string(filepath.Separator), "tmp", "ipscout-abs")
+	// t.TempDir returns an absolute path on every platform (a bare "/tmp/..."
+	// style path is not absolute on Windows, where IsAbs needs a drive letter).
+	abs := t.TempDir()
 
 	prefixed, err := PrefixProjectRoot(abs)
 	require.NoError(t, err)

--- a/manager/manager_test.go
+++ b/manager/manager_test.go
@@ -1,0 +1,243 @@
+package manager
+
+import (
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/dgraph-io/badger/v4"
+	"github.com/jonhadfield/ipscout/cache"
+	"github.com/jonhadfield/ipscout/providers"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testItemTTL     = time.Hour
+	testItemVersion = "1"
+	testAppVersion  = "0.0.1"
+	seededItemCount = 3
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+}
+
+// cachePath mirrors the path the manager Client builds internally from HomeDir.
+func cachePath(homeDir string) string {
+	return filepath.Join(homeDir, ".config", "ipscout")
+}
+
+// newTestSession returns a session with a real BadgerDB cache opened at the
+// manager's expected path, plus the homeDir used to build it.
+func newTestSession(t *testing.T) (*session.Session, string) {
+	t.Helper()
+
+	lg := discardLogger()
+	homeDir := t.TempDir()
+
+	db, err := cache.Create(lg, cachePath(homeDir))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	sess := &session.Session{
+		Logger: lg,
+		Stats:  session.CreateStats(),
+		Cache:  db,
+	}
+	sess.Config.Global.HomeDir = homeDir
+
+	return sess, homeDir
+}
+
+// seedKey builds a provider-prefixed cache key.
+func seedKey(name string) string {
+	return providers.CacheProviderPrefix + name
+}
+
+// seedItems writes seededItemCount items into the supplied cache.
+func seedItems(t *testing.T, db *badger.DB, lg *slog.Logger) []string {
+	t.Helper()
+
+	now := time.Now()
+	keys := []string{
+		seedKey("alpha"),
+		seedKey("bravo"),
+		seedKey("charlie"),
+	}
+
+	for _, k := range keys {
+		require.NoError(t, cache.UpsertWithTTL(lg, db, cache.Item{
+			Key:        k,
+			Value:      []byte(`{"data":"` + k + `"}`),
+			Version:    testItemVersion,
+			AppVersion: testAppVersion,
+			Created:    now,
+		}, testItemTTL))
+	}
+
+	return keys
+}
+
+func TestNewClient(t *testing.T) {
+	t.Parallel()
+
+	sess, _ := newTestSession(t)
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+	require.Equal(t, sess, c.Config)
+}
+
+func TestGetCacheItemsInfo(t *testing.T) {
+	t.Parallel()
+
+	sess, _ := newTestSession(t)
+	keys := seedItems(t, sess.Cache, sess.Logger)
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+
+	info, err := c.GetCacheItemsInfo()
+	require.NoError(t, err)
+	require.Len(t, info, seededItemCount)
+
+	gotKeys := make(map[string]CacheItemInfo, len(info))
+	for _, i := range info {
+		gotKeys[i.Key] = i
+	}
+
+	for _, k := range keys {
+		item, ok := gotKeys[k]
+		require.True(t, ok, "expected key %s in cache info", k)
+		require.Equal(t, testAppVersion, item.AppVersion)
+		require.True(t, item.ExpiresAt.After(time.Now()), "expected future expiry for %s", k)
+	}
+}
+
+func TestGetCacheItemsInfoEmpty(t *testing.T) {
+	t.Parallel()
+
+	sess, _ := newTestSession(t)
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+
+	info, err := c.GetCacheItemsInfo()
+	require.NoError(t, err)
+	require.Empty(t, info)
+}
+
+func TestCreateItemsInfoTable(t *testing.T) {
+	t.Parallel()
+
+	sess, _ := newTestSession(t)
+	seedItems(t, sess.Cache, sess.Logger)
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+
+	info, err := c.GetCacheItemsInfo()
+	require.NoError(t, err)
+
+	tw, err := c.CreateItemsInfoTable(info)
+	require.NoError(t, err)
+	require.NotNil(t, tw)
+
+	rendered := (*tw).Render()
+	require.NotEmpty(t, rendered)
+	require.Contains(t, rendered, "CACHE ITEMS")
+
+	for _, i := range info {
+		require.Contains(t, rendered, i.Key)
+	}
+}
+
+func TestCreateItemsInfoTableEmpty(t *testing.T) {
+	t.Parallel()
+
+	sess, _ := newTestSession(t)
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+
+	tw, err := c.CreateItemsInfoTable(nil)
+	require.NoError(t, err)
+	require.NotNil(t, tw)
+
+	rendered := (*tw).Render()
+	require.NotEmpty(t, rendered)
+	require.Contains(t, rendered, "no cache items found")
+}
+
+func TestList(t *testing.T) {
+	t.Parallel()
+
+	sess, _ := newTestSession(t)
+	seedItems(t, sess.Cache, sess.Logger)
+
+	// List opens its own cache from HomeDir, so close the test-held handle
+	// first to avoid a concurrent BadgerDB lock on the same directory.
+	require.NoError(t, sess.Cache.Close())
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+
+	require.NoError(t, c.List())
+}
+
+func TestGet(t *testing.T) {
+	t.Parallel()
+
+	sess, _ := newTestSession(t)
+	keys := seedItems(t, sess.Cache, sess.Logger)
+
+	require.NoError(t, sess.Cache.Close())
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+
+	require.NoError(t, c.Get(keys[0], false))
+	require.NoError(t, c.Get(keys[0], true))
+}
+
+func TestGetMissingKey(t *testing.T) {
+	t.Parallel()
+
+	sess, _ := newTestSession(t)
+	require.NoError(t, sess.Cache.Close())
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+
+	require.Error(t, c.Get(seedKey("does-not-exist"), false))
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	sess, homeDir := newTestSession(t)
+	keys := seedItems(t, sess.Cache, sess.Logger)
+
+	require.NoError(t, sess.Cache.Close())
+
+	c, err := NewClient(sess)
+	require.NoError(t, err)
+
+	require.NoError(t, c.Delete([]string{keys[0]}))
+
+	// Re-open the cache and confirm the deleted key is gone while others remain.
+	db, err := cache.Create(sess.Logger, cachePath(homeDir))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	exists, err := cache.CheckExists(sess.Logger, db, keys[0])
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	exists, err = cache.CheckExists(sess.Logger, db, keys[1])
+	require.NoError(t, err)
+	require.True(t, exists)
+}

--- a/present/present_test.go
+++ b/present/present_test.go
@@ -1,0 +1,116 @@
+package present
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jonhadfield/ipscout/providers"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	semVerTest    = "1.2.3"
+	priorityFirst = int32(1)
+)
+
+// newTestSession builds a minimal session.Session suitable for present tests.
+func newTestSession(style string) session.Session {
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+
+	sess := session.Session{
+		Logger: lg,
+		Stats:  session.CreateStats(),
+	}
+	sess.App.SemVer = semVerTest
+	sess.Config.Global.Style = style
+
+	return sess
+}
+
+func TestCSV(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{
+		"shodan": {"asn": "AS15169", "org": "Google LLC"},
+		"abuseipdb": {"score": 0}
+	}`)
+
+	require.NoError(t, CSV(&raw))
+}
+
+func TestCSVNonObjectProviderData(t *testing.T) {
+	t.Parallel()
+
+	// Provider value is an array, not a flat object, exercising the fallback path.
+	raw := json.RawMessage(`{"annotated": ["one", "two"]}`)
+
+	require.NoError(t, CSV(&raw))
+}
+
+func TestCSVInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`not-json`)
+
+	require.Error(t, CSV(&raw))
+}
+
+func TestJSON(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{"shodan":{"asn":"AS15169"}}`)
+
+	require.NoError(t, JSON(&raw))
+}
+
+func TestJSONInvalid(t *testing.T) {
+	t.Parallel()
+
+	raw := json.RawMessage(`{invalid`)
+
+	require.Error(t, JSON(&raw))
+}
+
+func TestOuterTableStyle(t *testing.T) {
+	t.Parallel()
+
+	styles := []string{txtASCII, txtYellow, txtCyan, "", "unknown"}
+	for _, style := range styles {
+		sess := newTestSession(style)
+		ts := OuterTableStyle(sess)
+		require.NotEmpty(t, ts.Name)
+	}
+}
+
+func TestInnerTableStyle(t *testing.T) {
+	t.Parallel()
+
+	styles := []string{txtASCII, txtYellow, txtRed, txtGreen, txtBlue, txtCyan, "", "unknown"}
+	for _, style := range styles {
+		sess := newTestSession(style)
+		ts := InnerTableStyle(sess)
+		require.NotEmpty(t, ts.Name)
+	}
+}
+
+func TestTables(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(txtASCII)
+
+	inner := table.NewWriter()
+	inner.AppendHeader(table.Row{"key", "value"})
+	inner.AppendRow(table.Row{"asn", "AS15169"})
+
+	priority := priorityFirst
+	tws := []providers.TableWithPriority{
+		{Table: &inner, Priority: &priority},
+		{Table: &inner, Priority: nil},
+	}
+
+	require.NotPanics(t, func() { Tables(&sess, tws) })
+}

--- a/process/process_more_test.go
+++ b/process/process_more_test.go
@@ -1,0 +1,316 @@
+package process
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jonhadfield/ipscout/cache"
+	"github.com/jonhadfield/ipscout/providers"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testPriority = int32(50)
+	outputJSON   = "json"
+	testProvider = "prov"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+}
+
+// configurableStub is a richer provider stub allowing per-test behaviour.
+type configurableStub struct {
+	enabled    bool
+	config     *session.Session
+	findResult []byte
+	findErr    error
+	tbl        *table.Writer
+	tblErr     error
+	initErr    error
+	priority   *int32
+}
+
+func (c configurableStub) Enabled() bool               { return c.enabled }
+func (c configurableStub) GetConfig() *session.Session { return c.config }
+func (c configurableStub) Initialise() error           { return c.initErr }
+func (c configurableStub) FindHost() ([]byte, error)   { return c.findResult, c.findErr }
+
+func (c configurableStub) CreateTable([]byte) (*table.Writer, error) {
+	return c.tbl, c.tblErr
+}
+
+func (c configurableStub) Priority() *int32 { return c.priority }
+
+func (configurableStub) RateHostData([]byte, []byte) (providers.RateResult, error) {
+	return providers.RateResult{}, nil
+}
+
+func (configurableStub) ExtractThreatIndicators([]byte) (*providers.ThreatIndicators, error) {
+	return nil, nil
+}
+
+func newTestSession(t *testing.T) *session.Session {
+	t.Helper()
+
+	lg := discardLogger()
+
+	db, err := cache.Create(lg, filepath.Join(t.TempDir(), ".config", "ipscout"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	sess := &session.Session{
+		Logger:       lg,
+		Stats:        session.CreateStats(),
+		Cache:        db,
+		Target:       os.Stdout,
+		Messages:     &session.Messages{},
+		HideProgress: true,
+		UseTestData:  true,
+	}
+
+	return sess
+}
+
+func TestMapsKeys(t *testing.T) {
+	m := map[string]int{"a": 1, "b": 2, "c": 3}
+	keys := mapsKeys(m)
+	require.Len(t, keys, 3)
+	require.ElementsMatch(t, []string{"a", "b", "c"}, keys)
+
+	require.Empty(t, mapsKeys(map[string]int{}))
+}
+
+func TestFilterProvidersByName(t *testing.T) {
+	runners := map[string]providers.ProviderClient{
+		"AbuseIPDB": configurableStub{enabled: true},
+		"Shodan":    configurableStub{enabled: true},
+		"AWS":       configurableStub{enabled: true},
+	}
+
+	// case-insensitive match on subset
+	filtered := filterProvidersByName(runners, []string{"shodan", "aws"})
+	require.Len(t, filtered, 2)
+	require.Contains(t, filtered, "Shodan")
+	require.Contains(t, filtered, "AWS")
+	require.NotContains(t, filtered, "AbuseIPDB")
+
+	// no matches
+	require.Empty(t, filterProvidersByName(runners, []string{"nonexistent"}))
+
+	// empty names
+	require.Empty(t, filterProvidersByName(runners, nil))
+}
+
+func TestGetEnabledProvidersMixed(t *testing.T) {
+	runners := map[string]providers.ProviderClient{
+		"on1": configurableStub{enabled: true},
+		"on2": configurableStub{enabled: true},
+		"off": configurableStub{enabled: false},
+	}
+
+	res := getEnabledProviders(runners)
+	require.Len(t, res, 2)
+	require.Contains(t, res, "on1")
+	require.Contains(t, res, "on2")
+	require.NotContains(t, res, "off")
+
+	require.Nil(t, getEnabledProviders(map[string]providers.ProviderClient{}))
+}
+
+func TestGetEnabledProviderClientsNoneEnabled(t *testing.T) {
+	// With a fresh session no providers are enabled by default, so this
+	// should report the "no providers enabled" error.
+	sess := session.New()
+
+	_, err := getEnabledProviderClients(*sess)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no providers enabled")
+}
+
+func TestStopSpinnerIfActiveNil(t *testing.T) {
+	// Must not panic with a nil spinner.
+	require.NotPanics(t, func() { stopSpinnerIfActive(nil) })
+}
+
+func TestFindHostsAggregates(t *testing.T) {
+	cfg := &session.Session{Logger: discardLogger()}
+
+	runners := map[string]providers.ProviderClient{
+		"withData": configurableStub{
+			enabled:    true,
+			config:     cfg,
+			findResult: []byte(`{"a":1}`),
+		},
+		"noData": configurableStub{
+			enabled:    true,
+			config:     cfg,
+			findResult: nil,
+		},
+		"errored": configurableStub{
+			enabled: true,
+			config:  cfg,
+			findErr: errors.New("lookup failed"),
+		},
+	}
+
+	results := findHosts(runners, true)
+	require.NotNil(t, results)
+
+	results.RLock()
+	defer results.RUnlock()
+
+	require.Len(t, results.m, 1)
+	require.Equal(t, []byte(`{"a":1}`), results.m["withData"])
+	require.NotContains(t, results.m, "noData")
+	require.NotContains(t, results.m, "errored")
+}
+
+func TestInitialiseProvidersHandlesErrors(t *testing.T) {
+	lg := discardLogger()
+
+	runners := map[string]providers.ProviderClient{
+		"ok":      configurableStub{enabled: true},
+		"failing": configurableStub{enabled: true, initErr: errors.New("boom")},
+		"skipped": configurableStub{enabled: false, initErr: errors.New("should not run")},
+	}
+
+	// hideProgress=true to avoid spinner output; must not panic.
+	require.NotPanics(t, func() { initialiseProviders(lg, runners, true) })
+}
+
+func TestGenerateTablesBuildsResults(t *testing.T) {
+	sess := newTestSession(t)
+
+	tw := table.NewWriter()
+	tw.AppendRow(table.Row{"col"})
+
+	prio := testPriority
+
+	runners := map[string]providers.ProviderClient{
+		"hasTable": configurableStub{
+			enabled:  true,
+			tbl:      &tw,
+			priority: &prio,
+		},
+		"nilTable": configurableStub{
+			enabled: true,
+			tbl:     nil,
+		},
+		"noResultData": configurableStub{
+			enabled: true,
+			tbl:     &tw,
+		},
+	}
+
+	results := &findHostsResults{m: map[string][]byte{
+		"hasTable": []byte(`{}`),
+		"nilTable": []byte(`{}`),
+		// noResultData intentionally absent → skipped
+	}}
+
+	tables := generateTables(sess, runners, results)
+	require.Len(t, tables, 1)
+	require.Equal(t, &prio, tables[0].Priority)
+	require.NotNil(t, tables[0].Table)
+}
+
+func TestGenerateTablesCreateError(t *testing.T) {
+	sess := newTestSession(t)
+
+	runners := map[string]providers.ProviderClient{
+		"errTable": configurableStub{
+			enabled: true,
+			tblErr:  errors.New("create failed"),
+		},
+	}
+
+	results := &findHostsResults{m: map[string][]byte{"errTable": []byte(`{}`)}}
+
+	tables := generateTables(sess, runners, results)
+	require.Empty(t, tables)
+}
+
+func TestOutputUnsupportedFormat(t *testing.T) {
+	sess := newTestSession(t)
+	sess.Config.Global.Output = "xml"
+
+	results := &findHostsResults{m: map[string][]byte{}}
+
+	err := output(sess, map[string]providers.ProviderClient{}, results)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported output format")
+}
+
+func TestOutputJSON(t *testing.T) {
+	sess := newTestSession(t)
+	sess.Config.Global.Output = outputJSON
+
+	results := &findHostsResults{m: map[string][]byte{
+		testProvider: []byte(`{"k":"v"}`),
+	}}
+
+	require.NoError(t, output(sess, map[string]providers.ProviderClient{}, results))
+}
+
+func TestOutputJSONMarshalErrorPropagates(t *testing.T) {
+	sess := newTestSession(t)
+	sess.Config.Global.Output = outputJSON
+
+	// nil data for a provider causes generateJSON to error.
+	results := &findHostsResults{m: map[string][]byte{"bad": nil}}
+
+	err := output(sess, map[string]providers.ProviderClient{}, results)
+	require.Error(t, err)
+}
+
+func TestOutputTable(t *testing.T) {
+	sess := newTestSession(t)
+	sess.Config.Global.Output = "table"
+
+	tw := table.NewWriter()
+	tw.AppendRow(table.Row{"data"})
+
+	prio := testPriority
+
+	runners := map[string]providers.ProviderClient{
+		testProvider: configurableStub{enabled: true, tbl: &tw, priority: &prio},
+	}
+
+	results := &findHostsResults{m: map[string][]byte{testProvider: []byte(`{}`)}}
+
+	require.NoError(t, output(sess, runners, results))
+}
+
+func TestOutputMessages(t *testing.T) {
+	sess := newTestSession(t)
+	sess.Messages.AddError("an error")
+	sess.Messages.AddWarn("a warning")
+	sess.Messages.AddInfo("some info")
+
+	require.NotPanics(t, func() { outputMessages(sess) })
+}
+
+func TestGenerateJSONRoundTrip(t *testing.T) {
+	results := &findHostsResults{m: map[string][]byte{
+		"one": []byte(`{"x":1}`),
+		"two": []byte(`{"y":2}`),
+	}}
+
+	raw, err := generateJSON(results)
+	require.NoError(t, err)
+
+	var out map[string]json.RawMessage
+
+	require.NoError(t, json.Unmarshal(raw, &out))
+	require.Len(t, out, 2)
+	require.JSONEq(t, `{"x":1}`, string(out["one"]))
+	require.JSONEq(t, `{"y":2}`, string(out["two"]))
+}

--- a/rate/rate_real_test.go
+++ b/rate/rate_real_test.go
@@ -1,0 +1,308 @@
+package rate
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/netip"
+	"path/filepath"
+	"testing"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jonhadfield/ipscout/providers"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeProviderClient is an in-memory ProviderClient used to exercise the
+// rating logic without any network access or real providers.
+type fakeProviderClient struct {
+	rate       providers.RateResult
+	indicators *providers.ThreatIndicators
+}
+
+func (f fakeProviderClient) Enabled() bool               { return true }
+func (f fakeProviderClient) GetConfig() *session.Session { return nil }
+func (f fakeProviderClient) Initialise() error           { return nil }
+func (f fakeProviderClient) FindHost() ([]byte, error)   { return nil, nil }
+func (f fakeProviderClient) Priority() *int32            { return nil }
+func (f fakeProviderClient) CreateTable([]byte) (*table.Writer, error) {
+	return nil, nil
+}
+
+func (f fakeProviderClient) RateHostData(_ []byte, _ []byte) (providers.RateResult, error) {
+	return f.rate, nil
+}
+
+func (f fakeProviderClient) ExtractThreatIndicators(_ []byte) (*providers.ThreatIndicators, error) {
+	return f.indicators, nil
+}
+
+const (
+	testScoreHigh     = 8.5
+	testHost          = "1.2.3.4"
+	providerAbuseIPDB = "abuseipdb"
+)
+
+func newTestSession(t *testing.T) *session.Session {
+	t.Helper()
+
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+
+	sess := &session.Session{
+		Logger: lg,
+		Stats:  session.CreateStats(),
+	}
+	sess.Host = netip.MustParseAddr(testHost)
+
+	return sess
+}
+
+func TestGetRatingConfigDefault(t *testing.T) {
+	t.Parallel()
+
+	// Empty path uses the embedded default rating config.
+	got, err := GetRatingConfig("")
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+	require.True(t, json.Valid(got))
+}
+
+func TestGetRatingConfigFromFile(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join("testdata", "ratingConfig.json")
+
+	got, err := GetRatingConfig(path)
+	require.NoError(t, err)
+	require.NotEmpty(t, got)
+	require.True(t, json.Valid(got))
+}
+
+func TestGetRatingConfigMissingFile(t *testing.T) {
+	t.Parallel()
+
+	got, err := GetRatingConfig(filepath.Join("testdata", "does-not-exist.json"))
+	require.Error(t, err)
+	require.Nil(t, got)
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	rater, err := New(sess)
+	require.NoError(t, err)
+	require.Same(t, sess, rater.Session)
+}
+
+func TestCreateResultsTableWithResults(t *testing.T) {
+	t.Parallel()
+
+	rater := Rater{Session: newTestSession(t)}
+
+	info := RatingOutput{
+		AverageScore:          testScoreHigh,
+		ProvidersThatDetected: 2,
+		Recommendation:        txtBlock,
+		Results: []rateResultsOutputItem{
+			{Provider: providerAbuseIPDB, Detected: true, Score: testScoreHigh, Reason: "known bad actor"},
+			{Provider: "shodan", Detected: false, Score: -1, Reason: ""},
+		},
+	}
+
+	tw, err := rater.CreateResultsTable(info)
+	require.NoError(t, err)
+	require.NotNil(t, tw)
+
+	rendered := (*tw).Render()
+	require.NotEmpty(t, rendered)
+	require.Contains(t, rendered, providerAbuseIPDB)
+	require.Contains(t, rendered, "shodan")
+	// Score of -1 is rendered as a dash.
+	require.Contains(t, rendered, "-")
+	require.Contains(t, rendered, testHost)
+}
+
+func TestCreateResultsTableEmpty(t *testing.T) {
+	t.Parallel()
+
+	rater := Rater{Session: newTestSession(t)}
+
+	tw, err := rater.CreateResultsTable(RatingOutput{})
+	require.NoError(t, err)
+	require.NotNil(t, tw)
+
+	rendered := (*tw).Render()
+	require.NotEmpty(t, rendered)
+	require.Contains(t, rendered, "no results found")
+}
+
+func TestCreateThreatIndicatorsTableWithIndicators(t *testing.T) {
+	t.Parallel()
+
+	rater := Rater{Session: newTestSession(t)}
+
+	ctis := []providers.ThreatIndicators{
+		{
+			Provider:   providerAbuseIPDB,
+			Indicators: map[string]string{"abuseConfidenceScore": "100"},
+		},
+		{
+			Provider:   "shodan",
+			Indicators: map[string]string{"openPorts": "22,80,443"},
+		},
+	}
+
+	tw, err := rater.CreateThreatIndicatorsTable(ctis)
+	require.NoError(t, err)
+	require.NotNil(t, tw)
+
+	rendered := (*tw).Render()
+	require.NotEmpty(t, rendered)
+	require.Contains(t, rendered, providerAbuseIPDB)
+	require.Contains(t, rendered, "abuseConfidenceScore")
+	require.Contains(t, rendered, testHost)
+}
+
+func TestCreateThreatIndicatorsTableEmpty(t *testing.T) {
+	t.Parallel()
+
+	rater := Rater{Session: newTestSession(t)}
+
+	tw, err := rater.CreateThreatIndicatorsTable(nil)
+	require.NoError(t, err)
+	require.NotNil(t, tw)
+
+	rendered := (*tw).Render()
+	require.NotEmpty(t, rendered)
+	require.Contains(t, rendered, "no threat indicators found")
+}
+
+func TestGetEnabledProviders(t *testing.T) {
+	t.Parallel()
+
+	// Empty input yields nil (no enabled providers).
+	require.Nil(t, getEnabledProviders(map[string]providers.ProviderClient{}))
+}
+
+func TestMapsKeys(t *testing.T) {
+	t.Parallel()
+
+	m := map[string]int{"a": 1, "b": 2, "c": 3}
+
+	keys := mapsKeys(m)
+	require.Len(t, keys, len(m))
+	require.ElementsMatch(t, []string{"a", "b", "c"}, keys)
+}
+
+func TestStaticRateFindHostsResultsBlock(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	runners := map[string]providers.ProviderClient{
+		providerAbuseIPDB: fakeProviderClient{rate: providers.RateResult{
+			Detected: true,
+			Score:    testScoreHigh,
+			Reasons:  []string{"known bad actor"},
+		}},
+	}
+
+	results := &findHostsResults{m: map[string][]byte{providerAbuseIPDB: []byte("{}")}}
+
+	cfg, err := GetRatingConfig("")
+	require.NoError(t, err)
+
+	out, err := staticRateFindHostsResults(sess, runners, results, cfg)
+	require.NoError(t, err)
+	require.Equal(t, 1, out.ProvidersThatDetected)
+	require.InDelta(t, testScoreHigh, out.AverageScore, 0.001)
+	require.Equal(t, txtBlock, out.Recommendation)
+	require.Len(t, out.Results, 1)
+}
+
+func TestStaticRateFindHostsResultsNoBlockOverride(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	runners := map[string]providers.ProviderClient{
+		"trusted": fakeProviderClient{rate: providers.RateResult{
+			Detected: true,
+			Score:    testScoreHigh,
+			Reasons:  []string{"on allow list"},
+			Threat:   "noblock",
+		}},
+	}
+
+	results := &findHostsResults{m: map[string][]byte{"trusted": []byte("{}")}}
+
+	cfg, err := GetRatingConfig("")
+	require.NoError(t, err)
+
+	out, err := staticRateFindHostsResults(sess, runners, results, cfg)
+	require.NoError(t, err)
+	// noblock threat forces an allow recommendation regardless of score.
+	require.Equal(t, txtAllow, out.Recommendation)
+}
+
+func TestStaticRateFindHostsResultsNoDetection(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	runners := map[string]providers.ProviderClient{
+		"clean": fakeProviderClient{rate: providers.RateResult{Detected: false}},
+	}
+
+	results := &findHostsResults{m: map[string][]byte{"clean": []byte("{}")}}
+
+	cfg, err := GetRatingConfig("")
+	require.NoError(t, err)
+
+	_, err = staticRateFindHostsResults(sess, runners, results, cfg)
+	require.Error(t, err)
+}
+
+func TestStaticRateFindHostsResultsBadConfig(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	_, err := staticRateFindHostsResults(sess, nil, &findHostsResults{m: nil}, []byte("not json"))
+	require.Error(t, err)
+}
+
+func TestExtractThreatIndicators(t *testing.T) {
+	t.Parallel()
+
+	sess := newTestSession(t)
+
+	runners := map[string]providers.ProviderClient{
+		providerAbuseIPDB: fakeProviderClient{indicators: &providers.ThreatIndicators{
+			Provider:   providerAbuseIPDB,
+			Indicators: map[string]string{"abuseConfidenceScore": "100"},
+		}},
+		"empty": fakeProviderClient{indicators: nil},
+	}
+
+	results := &findHostsResults{m: map[string][]byte{
+		providerAbuseIPDB: []byte("{}"),
+		"empty":           []byte("{}"),
+	}}
+
+	tis, err := extractThreatIndicators(sess, runners, results)
+	require.NoError(t, err)
+	// Only the provider returning non-nil indicators is included.
+	require.Len(t, tis, 1)
+	require.Equal(t, providerAbuseIPDB, tis[0].Provider)
+}
+
+func TestStopSpinnerIfActiveNil(t *testing.T) {
+	t.Parallel()
+
+	// Should not panic with a nil spinner.
+	require.NotPanics(t, func() { stopSpinnerIfActive(nil) })
+}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,0 +1,160 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/jonhadfield/ipscout/session"
+)
+
+// expectedProviderCount is the number of provider entries currently registered
+// in All(). Update this constant if providers are added or removed.
+const expectedProviderCount = 27
+
+func TestAllReturnsEntries(t *testing.T) {
+	t.Parallel()
+
+	entries := All()
+
+	if len(entries) == 0 {
+		t.Fatal("All() returned no entries")
+	}
+
+	if len(entries) != expectedProviderCount {
+		t.Errorf("All() returned %d entries, want %d", len(entries), expectedProviderCount)
+	}
+}
+
+func TestAllContainsKnownProviders(t *testing.T) {
+	t.Parallel()
+
+	names := make(map[string]bool)
+	for _, e := range All() {
+		names[e.Name] = true
+	}
+
+	known := []string{
+		"shodan",
+		"aws",
+		"abuseipdb",
+		"azure",
+		"gcp",
+		"virustotal",
+		"ptr",
+		"annotated",
+	}
+
+	for _, n := range known {
+		if !names[n] {
+			t.Errorf("All() missing expected provider %q", n)
+		}
+	}
+}
+
+func TestAllEntryFieldsPopulated(t *testing.T) {
+	t.Parallel()
+
+	for _, e := range All() {
+		if e.Name == "" {
+			t.Error("found entry with empty Name")
+		}
+
+		if e.Enabled == nil {
+			t.Errorf("entry %q has nil Enabled func", e.Name)
+		}
+
+		if e.APIKey == nil {
+			t.Errorf("entry %q has nil APIKey func", e.Name)
+		}
+
+		if e.NewClient == nil {
+			t.Errorf("entry %q has nil NewClient func", e.Name)
+		}
+	}
+}
+
+func TestAllNamesUnique(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]bool)
+
+	for _, e := range All() {
+		if seen[e.Name] {
+			t.Errorf("duplicate provider name %q in All()", e.Name)
+		}
+
+		seen[e.Name] = true
+	}
+}
+
+func TestEntryEnabledAccessor(t *testing.T) {
+	t.Parallel()
+
+	// A zero-value session has all Enabled pointers nil, so each Enabled
+	// accessor should run without panicking and return nil.
+	var sess session.Session
+
+	for _, e := range All() {
+		if got := e.Enabled(sess); got != nil {
+			t.Errorf("entry %q Enabled() on zero session = %v, want nil", e.Name, got)
+		}
+	}
+}
+
+func TestEntryAPIKeyAccessor(t *testing.T) {
+	t.Parallel()
+
+	// A zero-value session has empty API keys, so every APIKey accessor
+	// (both the real getters and the noKey helper) should return "".
+	var sess session.Session
+
+	for _, e := range All() {
+		if got := e.APIKey(sess); got != "" {
+			t.Errorf("entry %q APIKey() on zero session = %q, want empty", e.Name, got)
+		}
+	}
+}
+
+func TestSupportsRatingFlags(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]bool{
+		"shodan":     true,
+		"abuseipdb":  true,
+		"azurewaf":   false,
+		"scaleway":   false,
+		"vultr":      false,
+		"ptr":        false,
+		"M247":       false,
+		"googlesc":   false,
+		"aws":        true,
+		"virustotal": true,
+	}
+
+	got := make(map[string]bool)
+	for _, e := range All() {
+		got[e.Name] = e.SupportsRating
+	}
+
+	for name, expected := range want {
+		actual, ok := got[name]
+		if !ok {
+			t.Errorf("provider %q not found in All()", name)
+
+			continue
+		}
+
+		if actual != expected {
+			t.Errorf("provider %q SupportsRating = %v, want %v", name, actual, expected)
+		}
+	}
+}
+
+func TestNoKeyHelper(t *testing.T) {
+	t.Parallel()
+
+	var sess session.Session
+
+	if got := noKey(sess); got != "" {
+		t.Errorf("noKey() = %q, want empty string", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #96 and #97. Extends the test effort from providers to the core (non-provider) packages.

## Coverage

Total statement coverage **37.0% → 48.4%**:

| Package | Before | After |
|---|---|---|
| registry | 0% | 100% |
| present | 0% | 96.6% |
| manager | 0% | 89.2% |
| config | 0% | 87.2% |
| cmd | 0% | 70.2% |
| helpers | 0% | 70.2% |
| process | 10.2% | 62.4% |
| rate | 0% | 40.4% |

## Approach

Each test exercises real functions with no network and no OpenAI calls, using a temporary BadgerDB cache where one is needed (`Close` registered via `t.Cleanup` for Windows). 8 new test files, all additive — no source changes.

Note: `helpers` showed 0% before despite `ParseHost` being tested, because that test lives in the `cmd` package and didn't count toward `helpers`; it now has its own `helpers/helpers_test.go`.

## Deliberately left uncovered (network / AI / process-exit bound)

- `process.Run` — opens a real cache under `$HOME`, initialises live providers, queries the network.
- `rate.Run` / `rate.aiRate` — OpenAI calls; `rate.findHosts` queries providers.
- cobra `RunE` bodies that query providers; `rate config`'s RunE calls `os.Exit()` in every branch so it can't run in-process. Command construction and pure helpers are covered.

## Gate

Raises the coverage ratchet floor **35.0 → 45.0** in both `make cover-check` and the CI step.

## Verification

- [x] full suite passes sequentially (`go test -p 1 ./...`) — no cache-lock conflicts
- [x] `golangci-lint run ./...` → 0 issues
- [x] coverage gate passes at 48.4% ≥ 45.0% floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)