### PR TITLE
refactor: drive `ipscout config` from the provider registry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,10 +16,11 @@ import (
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/jonhadfield/ipscout/cache"
 	"github.com/jonhadfield/ipscout/present"
+	"github.com/jonhadfield/ipscout/providers/annotated"
+	"github.com/jonhadfield/ipscout/providers/ipurl"
+	"github.com/jonhadfield/ipscout/registry"
 	"github.com/jonhadfield/ipscout/session"
 )
-
-const indentSpaces = 2
 
 type Client struct {
 	Sess *session.Session
@@ -47,259 +48,44 @@ func (c *Client) CreateConfigTable() (*table.Writer, error) {
 	tw.AppendRow(table.Row{color.WhiteString("%sopenai_api_key", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces)), openAIAPIKeyDefinedOutput})
 
 	tw.AppendRow(table.Row{color.HiYellowString("Providers")})
-	// abuseipdb
-	tw.AppendRow(table.Row{color.HiCyanString("%sAbuseIPDB", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
 
-	abuseipdbEnabled := false
-	if c.Sess.Providers.AbuseIPDB.Enabled != nil {
-		abuseipdbEnabled = *c.Sess.Providers.AbuseIPDB.Enabled
-	}
+	providerIndent := strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces)
+	fieldIndent := strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), abuseipdbEnabled})
+	// Render every registered provider from the registry so new providers
+	// appear here automatically and can never be silently omitted.
+	for _, entry := range registry.All() {
+		tw.AppendRow(table.Row{color.HiCyanString("%s%s", providerIndent, entry.DisplayName)})
 
-	// alibaba
-	tw.AppendRow(table.Row{color.HiCyanString("%sAlibaba", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	alibabaEnabled := false
-	if c.Sess.Providers.Alibaba.Enabled != nil {
-		alibabaEnabled = *c.Sess.Providers.Alibaba.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), alibabaEnabled})
-
-	// annotated
-
-	tw.AppendRow(table.Row{color.HiCyanString("%sAnnotated", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	annotatedEnabled := false
-	if c.Sess.Providers.Annotated.Enabled != nil {
-		annotatedEnabled = *c.Sess.Providers.Annotated.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), annotatedEnabled})
-
-	for x, path := range c.Sess.Providers.Annotated.Paths {
-		var pathsTitle string
-		if x == 0 {
-			pathsTitle = "paths"
+		enabled := false
+		if e := entry.Enabled(*c.Sess); e != nil {
+			enabled = *e
 		}
 
-		tw.AppendRow(table.Row{color.WhiteString("%s%s", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces), pathsTitle), path})
-	}
+		tw.AppendRow(table.Row{color.WhiteString("%senabled", fieldIndent), enabled})
 
-	// aws
-	tw.AppendRow(table.Row{color.HiCyanString("%sAWS", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
+		// A few providers have additional list fields worth displaying.
+		switch entry.Name {
+		case annotated.ProviderName:
+			for x, path := range c.Sess.Providers.Annotated.Paths {
+				var title string
+				if x == 0 {
+					title = "paths"
+				}
 
-	awsEnabled := false
-	if c.Sess.Providers.AWS.Enabled != nil {
-		awsEnabled = *c.Sess.Providers.AWS.Enabled
-	}
+				tw.AppendRow(table.Row{color.WhiteString("%s%s", fieldIndent, title), path})
+			}
+		case ipurl.ProviderName:
+			for x, url := range c.Sess.Providers.IPURL.URLs {
+				var title string
+				if x == 0 {
+					title = "urls"
+				}
 
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), awsEnabled})
-
-	// azure
-	tw.AppendRow(table.Row{color.HiCyanString("%sAzure", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	azureEnabled := false
-	if c.Sess.Providers.Azure.Enabled != nil {
-		azureEnabled = *c.Sess.Providers.Azure.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), azureEnabled})
-
-	// criminalip
-	tw.AppendRow(table.Row{color.HiCyanString("%sCriminalIP", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	criminalipEnabled := false
-	if c.Sess.Providers.CriminalIP.Enabled != nil {
-		criminalipEnabled = *c.Sess.Providers.CriminalIP.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), criminalipEnabled})
-
-	// digitalocean
-	tw.AppendRow(table.Row{color.HiCyanString("%sDigitalocean", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	digitaloceanEnabled := false
-	if c.Sess.Providers.DigitalOcean.Enabled != nil {
-		digitaloceanEnabled = *c.Sess.Providers.DigitalOcean.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), digitaloceanEnabled})
-
-	// gcp
-	tw.AppendRow(table.Row{color.HiCyanString("%sGCP", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	gcpEnabled := false
-	if c.Sess.Providers.GCP.Enabled != nil {
-		gcpEnabled = *c.Sess.Providers.GCP.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), gcpEnabled})
-
-	// google
-	tw.AppendRow(table.Row{color.HiCyanString("%sGoogle", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	googleEnabled := false
-	if c.Sess.Providers.Google.Enabled != nil {
-		googleEnabled = *c.Sess.Providers.Google.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), googleEnabled})
-
-	// googlebot
-	tw.AppendRow(table.Row{color.HiCyanString("%sGooglebot", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	googlebotEnabled := false
-	if c.Sess.Providers.Googlebot.Enabled != nil {
-		googlebotEnabled = *c.Sess.Providers.Googlebot.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), googlebotEnabled})
-
-	// hetzner
-	tw.AppendRow(table.Row{color.HiCyanString("%sHetzner", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	hetznerEnabled := false
-	if c.Sess.Providers.Hetzner.Enabled != nil {
-		hetznerEnabled = *c.Sess.Providers.Hetzner.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), hetznerEnabled})
-
-	// iCloud Private Relay
-	tw.AppendRow(table.Row{color.HiCyanString("%siCloud Private Relay", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	icloudPREnabled := false
-	if c.Sess.Providers.ICloudPR.Enabled != nil {
-		icloudPREnabled = *c.Sess.Providers.ICloudPR.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), icloudPREnabled})
-
-	// ipapi
-	tw.AppendRow(table.Row{color.HiCyanString("%sIPAPI", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	ipapiEnabled := false
-	if c.Sess.Providers.IPAPI.Enabled != nil {
-		ipapiEnabled = *c.Sess.Providers.IPAPI.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), ipapiEnabled})
-
-	// IPURL
-	tw.AppendRow(table.Row{color.HiCyanString("%sIPURL", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	ipurlEnabled := false
-	if c.Sess.Providers.IPURL.Enabled != nil {
-		ipurlEnabled = *c.Sess.Providers.IPURL.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), ipurlEnabled})
-
-	for x, url := range c.Sess.Providers.IPURL.URLs {
-		var urlsTitle string
-
-		if x == 0 {
-			urlsTitle = "urls"
+				tw.AppendRow(table.Row{color.WhiteString("%s%s", fieldIndent, title), url})
+			}
 		}
-
-		tw.AppendRow(table.Row{color.WhiteString("%s%s", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces), urlsTitle), url})
 	}
-
-	// linode
-	tw.AppendRow(table.Row{color.HiCyanString("%sLinode", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	linodeEnabled := false
-
-	if c.Sess.Providers.Linode.Enabled != nil {
-		linodeEnabled = *c.Sess.Providers.Linode.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), linodeEnabled})
-
-	// m247
-	tw.AppendRow(table.Row{color.HiCyanString("%sM247", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	m247Enabled := false
-
-	if c.Sess.Providers.M247.Enabled != nil {
-		m247Enabled = *c.Sess.Providers.M247.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), m247Enabled})
-
-	// ovh
-	tw.AppendRow(table.Row{color.HiCyanString("%sOVH", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	ovhEnabled := false
-
-	if c.Sess.Providers.OVH.Enabled != nil {
-		ovhEnabled = *c.Sess.Providers.OVH.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), ovhEnabled})
-
-	// ptr
-	tw.AppendRow(table.Row{color.HiCyanString("%sPTR", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	ptrEnabled := false
-	if c.Sess.Providers.PTR.Enabled != nil {
-		ptrEnabled = *c.Sess.Providers.PTR.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), ptrEnabled})
-
-	// scaleway
-	tw.AppendRow(table.Row{color.HiCyanString("%sScaleway", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	scalewayEnabled := false
-	if c.Sess.Providers.Scaleway.Enabled != nil {
-		scalewayEnabled = *c.Sess.Providers.Scaleway.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), scalewayEnabled})
-
-	// shodan
-	tw.AppendRow(table.Row{color.HiCyanString("%sShodan", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	shodanEnabled := false
-	if c.Sess.Providers.Shodan.Enabled != nil {
-		shodanEnabled = *c.Sess.Providers.Shodan.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), shodanEnabled})
-
-	// virustotal
-	tw.AppendRow(table.Row{color.HiCyanString("%sVirusTotal", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	virustotalEnabled := false
-	if c.Sess.Providers.VirusTotal.Enabled != nil {
-		virustotalEnabled = *c.Sess.Providers.VirusTotal.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), virustotalEnabled})
-
-	// vultr
-	tw.AppendRow(table.Row{color.HiCyanString("%sVultr", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	vultrEnabled := false
-	if c.Sess.Providers.Vultr.Enabled != nil {
-		vultrEnabled = *c.Sess.Providers.Vultr.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", providers.IndentSpaces*c.Sess.Config.Global.IndentSpaces)), vultrEnabled})
-
-	// zscaler
-	tw.AppendRow(table.Row{color.HiCyanString("%sZscaler", strings.Repeat(" ", c.Sess.Config.Global.IndentSpaces))})
-
-	zscalerEnabled := false
-
-	if c.Sess.Providers.Zscaler.Enabled != nil {
-		zscalerEnabled = *c.Sess.Providers.Zscaler.Enabled
-	}
-
-	tw.AppendRow(table.Row{color.WhiteString("%senabled", strings.Repeat(" ", indentSpaces*c.Sess.Config.Global.IndentSpaces)), zscalerEnabled})
 
 	// end
 	tw.SetColumnConfigs([]table.ColumnConfig{

--- a/rate/defaultRatingConfig.json
+++ b/rate/defaultRatingConfig.json
@@ -69,6 +69,9 @@
     "googlebot": {
       "defaultMatchScore": 1.0
     },
+    "googlesc": {
+      "defaultMatchScore": 1.0
+    },
     "hetzner": {
       "defaultMatchScore": 8.0
     },

--- a/rate/rate_test.go
+++ b/rate/rate_test.go
@@ -36,4 +36,5 @@ func TestDefaultConfigHostingProviderScores(t *testing.T) {
 	require.Equal(t, float64(8), ratingConfig.ProviderRatingsConfigs.M247.DefaultMatchScore)
 	require.Equal(t, float64(8), ratingConfig.ProviderRatingsConfigs.Scaleway.DefaultMatchScore)
 	require.Equal(t, float64(8), ratingConfig.ProviderRatingsConfigs.Vultr.DefaultMatchScore)
+	require.Equal(t, float64(1), ratingConfig.ProviderRatingsConfigs.GoogleSC.DefaultMatchScore)
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -34,7 +34,9 @@ import (
 
 // Entry describes a provider and how to instantiate it.
 type Entry struct {
-	Name           string
+	Name string
+	// DisplayName is the human-friendly name shown in `ipscout config`.
+	DisplayName    string
 	Enabled        func(sess session.Session) *bool
 	APIKey         func(sess session.Session) string
 	NewClient      func(sess session.Session) (providers.ProviderClient, error)
@@ -45,33 +47,33 @@ type Entry struct {
 // This is the single source of truth — process and rate both call this.
 func All() []Entry {
 	return []Entry{
-		{Name: abuseipdb.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.AbuseIPDB.Enabled }, APIKey: func(s session.Session) string { return s.Providers.AbuseIPDB.APIKey }, NewClient: abuseipdb.NewClient, SupportsRating: true},
-		{Name: alibaba.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Alibaba.Enabled }, APIKey: noKey, NewClient: alibaba.NewProviderClient, SupportsRating: true},
-		{Name: annotated.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Annotated.Enabled }, APIKey: noKey, NewClient: annotated.NewProviderClient, SupportsRating: true},
-		{Name: aws.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.AWS.Enabled }, APIKey: noKey, NewClient: aws.NewProviderClient, SupportsRating: true},
-		{Name: azure.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Azure.Enabled }, APIKey: noKey, NewClient: azure.NewProviderClient, SupportsRating: true},
-		{Name: azurewaf.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.AzureWAF.Enabled }, APIKey: noKey, NewClient: azurewaf.NewProviderClient, SupportsRating: false},
-		{Name: bingbot.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Bingbot.Enabled }, APIKey: noKey, NewClient: bingbot.NewProviderClient, SupportsRating: true},
-		{Name: criminalip.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.CriminalIP.Enabled }, APIKey: func(s session.Session) string { return s.Providers.CriminalIP.APIKey }, NewClient: criminalip.NewProviderClient, SupportsRating: true},
-		{Name: digitalocean.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.DigitalOcean.Enabled }, APIKey: noKey, NewClient: digitalocean.NewProviderClient, SupportsRating: true},
-		{Name: gcp.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.GCP.Enabled }, APIKey: noKey, NewClient: gcp.NewProviderClient, SupportsRating: true},
-		{Name: google.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Google.Enabled }, APIKey: noKey, NewClient: google.NewProviderClient, SupportsRating: true},
-		{Name: googlebot.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Googlebot.Enabled }, APIKey: noKey, NewClient: googlebot.NewProviderClient, SupportsRating: true},
-		{Name: googlesc.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.GoogleSC.Enabled }, APIKey: noKey, NewClient: googlesc.NewProviderClient, SupportsRating: false},
-		{Name: hetzner.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Hetzner.Enabled }, APIKey: noKey, NewClient: hetzner.NewProviderClient, SupportsRating: true},
-		{Name: ipapi.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.IPAPI.Enabled }, APIKey: noKey, NewClient: ipapi.NewProviderClient, SupportsRating: true},
-		{Name: ipqs.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.IPQS.Enabled }, APIKey: func(s session.Session) string { return s.Providers.IPQS.APIKey }, NewClient: ipqs.NewProviderClient, SupportsRating: true},
-		{Name: ipurl.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.IPURL.Enabled }, APIKey: noKey, NewClient: ipurl.NewProviderClient, SupportsRating: true},
-		{Name: icloudpr.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.ICloudPR.Enabled }, APIKey: noKey, NewClient: icloudpr.NewProviderClient, SupportsRating: true},
-		{Name: linode.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Linode.Enabled }, APIKey: noKey, NewClient: linode.NewProviderClient, SupportsRating: true},
-		{Name: m247.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.M247.Enabled }, APIKey: noKey, NewClient: m247.NewProviderClient, SupportsRating: true},
-		{Name: ovh.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.OVH.Enabled }, APIKey: noKey, NewClient: ovh.NewProviderClient, SupportsRating: true},
-		{Name: scaleway.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Scaleway.Enabled }, APIKey: noKey, NewClient: scaleway.NewProviderClient, SupportsRating: true},
-		{Name: ptr.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.PTR.Enabled }, APIKey: noKey, NewClient: ptr.NewProviderClient, SupportsRating: false},
-		{Name: shodan.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Shodan.Enabled }, APIKey: func(s session.Session) string { return s.Providers.Shodan.APIKey }, NewClient: shodan.NewProviderClient, SupportsRating: true},
-		{Name: virustotal.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.VirusTotal.Enabled }, APIKey: func(s session.Session) string { return s.Providers.VirusTotal.APIKey }, NewClient: virustotal.NewProviderClient, SupportsRating: true},
-		{Name: vultr.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Vultr.Enabled }, APIKey: noKey, NewClient: vultr.NewProviderClient, SupportsRating: true},
-		{Name: zscaler.ProviderName, Enabled: func(s session.Session) *bool { return s.Providers.Zscaler.Enabled }, APIKey: noKey, NewClient: zscaler.NewProviderClient, SupportsRating: true},
+		{Name: abuseipdb.ProviderName, DisplayName: "AbuseIPDB", Enabled: func(s session.Session) *bool { return s.Providers.AbuseIPDB.Enabled }, APIKey: func(s session.Session) string { return s.Providers.AbuseIPDB.APIKey }, NewClient: abuseipdb.NewClient, SupportsRating: true},
+		{Name: alibaba.ProviderName, DisplayName: "Alibaba", Enabled: func(s session.Session) *bool { return s.Providers.Alibaba.Enabled }, APIKey: noKey, NewClient: alibaba.NewProviderClient, SupportsRating: true},
+		{Name: annotated.ProviderName, DisplayName: "Annotated", Enabled: func(s session.Session) *bool { return s.Providers.Annotated.Enabled }, APIKey: noKey, NewClient: annotated.NewProviderClient, SupportsRating: true},
+		{Name: aws.ProviderName, DisplayName: "AWS", Enabled: func(s session.Session) *bool { return s.Providers.AWS.Enabled }, APIKey: noKey, NewClient: aws.NewProviderClient, SupportsRating: true},
+		{Name: azure.ProviderName, DisplayName: "Azure", Enabled: func(s session.Session) *bool { return s.Providers.Azure.Enabled }, APIKey: noKey, NewClient: azure.NewProviderClient, SupportsRating: true},
+		{Name: azurewaf.ProviderName, DisplayName: "Azure WAF", Enabled: func(s session.Session) *bool { return s.Providers.AzureWAF.Enabled }, APIKey: noKey, NewClient: azurewaf.NewProviderClient, SupportsRating: false},
+		{Name: bingbot.ProviderName, DisplayName: "Bingbot", Enabled: func(s session.Session) *bool { return s.Providers.Bingbot.Enabled }, APIKey: noKey, NewClient: bingbot.NewProviderClient, SupportsRating: true},
+		{Name: criminalip.ProviderName, DisplayName: "CriminalIP", Enabled: func(s session.Session) *bool { return s.Providers.CriminalIP.Enabled }, APIKey: func(s session.Session) string { return s.Providers.CriminalIP.APIKey }, NewClient: criminalip.NewProviderClient, SupportsRating: true},
+		{Name: digitalocean.ProviderName, DisplayName: "DigitalOcean", Enabled: func(s session.Session) *bool { return s.Providers.DigitalOcean.Enabled }, APIKey: noKey, NewClient: digitalocean.NewProviderClient, SupportsRating: true},
+		{Name: gcp.ProviderName, DisplayName: "GCP", Enabled: func(s session.Session) *bool { return s.Providers.GCP.Enabled }, APIKey: noKey, NewClient: gcp.NewProviderClient, SupportsRating: true},
+		{Name: google.ProviderName, DisplayName: "Google", Enabled: func(s session.Session) *bool { return s.Providers.Google.Enabled }, APIKey: noKey, NewClient: google.NewProviderClient, SupportsRating: true},
+		{Name: googlebot.ProviderName, DisplayName: "Googlebot", Enabled: func(s session.Session) *bool { return s.Providers.Googlebot.Enabled }, APIKey: noKey, NewClient: googlebot.NewProviderClient, SupportsRating: true},
+		{Name: googlesc.ProviderName, DisplayName: "Google Special-case Crawlers", Enabled: func(s session.Session) *bool { return s.Providers.GoogleSC.Enabled }, APIKey: noKey, NewClient: googlesc.NewProviderClient, SupportsRating: true},
+		{Name: hetzner.ProviderName, DisplayName: "Hetzner", Enabled: func(s session.Session) *bool { return s.Providers.Hetzner.Enabled }, APIKey: noKey, NewClient: hetzner.NewProviderClient, SupportsRating: true},
+		{Name: ipapi.ProviderName, DisplayName: "IPAPI", Enabled: func(s session.Session) *bool { return s.Providers.IPAPI.Enabled }, APIKey: noKey, NewClient: ipapi.NewProviderClient, SupportsRating: true},
+		{Name: ipqs.ProviderName, DisplayName: "IPQualityScore", Enabled: func(s session.Session) *bool { return s.Providers.IPQS.Enabled }, APIKey: func(s session.Session) string { return s.Providers.IPQS.APIKey }, NewClient: ipqs.NewProviderClient, SupportsRating: true},
+		{Name: ipurl.ProviderName, DisplayName: "IPURL", Enabled: func(s session.Session) *bool { return s.Providers.IPURL.Enabled }, APIKey: noKey, NewClient: ipurl.NewProviderClient, SupportsRating: true},
+		{Name: icloudpr.ProviderName, DisplayName: "iCloud Private Relay", Enabled: func(s session.Session) *bool { return s.Providers.ICloudPR.Enabled }, APIKey: noKey, NewClient: icloudpr.NewProviderClient, SupportsRating: true},
+		{Name: linode.ProviderName, DisplayName: "Linode", Enabled: func(s session.Session) *bool { return s.Providers.Linode.Enabled }, APIKey: noKey, NewClient: linode.NewProviderClient, SupportsRating: true},
+		{Name: m247.ProviderName, DisplayName: "M247", Enabled: func(s session.Session) *bool { return s.Providers.M247.Enabled }, APIKey: noKey, NewClient: m247.NewProviderClient, SupportsRating: true},
+		{Name: ovh.ProviderName, DisplayName: "OVH", Enabled: func(s session.Session) *bool { return s.Providers.OVH.Enabled }, APIKey: noKey, NewClient: ovh.NewProviderClient, SupportsRating: true},
+		{Name: scaleway.ProviderName, DisplayName: "Scaleway", Enabled: func(s session.Session) *bool { return s.Providers.Scaleway.Enabled }, APIKey: noKey, NewClient: scaleway.NewProviderClient, SupportsRating: true},
+		{Name: ptr.ProviderName, DisplayName: "PTR", Enabled: func(s session.Session) *bool { return s.Providers.PTR.Enabled }, APIKey: noKey, NewClient: ptr.NewProviderClient, SupportsRating: false},
+		{Name: shodan.ProviderName, DisplayName: "Shodan", Enabled: func(s session.Session) *bool { return s.Providers.Shodan.Enabled }, APIKey: func(s session.Session) string { return s.Providers.Shodan.APIKey }, NewClient: shodan.NewProviderClient, SupportsRating: true},
+		{Name: virustotal.ProviderName, DisplayName: "VirusTotal", Enabled: func(s session.Session) *bool { return s.Providers.VirusTotal.Enabled }, APIKey: func(s session.Session) string { return s.Providers.VirusTotal.APIKey }, NewClient: virustotal.NewProviderClient, SupportsRating: true},
+		{Name: vultr.ProviderName, DisplayName: "Vultr", Enabled: func(s session.Session) *bool { return s.Providers.Vultr.Enabled }, APIKey: noKey, NewClient: vultr.NewProviderClient, SupportsRating: true},
+		{Name: zscaler.ProviderName, DisplayName: "Zscaler", Enabled: func(s session.Session) *bool { return s.Providers.Zscaler.Enabled }, APIKey: noKey, NewClient: zscaler.NewProviderClient, SupportsRating: true},
 	}
 }
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -126,7 +126,7 @@ func TestSupportsRatingFlags(t *testing.T) {
 		"vultr":      true,
 		"ptr":        false,
 		"M247":       true,
-		"googlesc":   false,
+		"googlesc":   true,
 		"aws":        true,
 		"virustotal": true,
 	}
@@ -147,6 +147,28 @@ func TestSupportsRatingFlags(t *testing.T) {
 		if actual != expected {
 			t.Errorf("provider %q SupportsRating = %v, want %v", name, actual, expected)
 		}
+	}
+}
+
+// TestEveryEntryHasDisplayName guards the registry-driven `ipscout config`
+// output: a provider without a DisplayName would render with a blank header,
+// so every entry must supply one. This is the guardrail that prevents
+// providers from being silently omitted from the config display.
+func TestEveryEntryHasDisplayName(t *testing.T) {
+	t.Parallel()
+
+	seen := make(map[string]bool)
+
+	for _, e := range All() {
+		if e.DisplayName == "" {
+			t.Errorf("provider %q has an empty DisplayName", e.Name)
+		}
+
+		if seen[e.DisplayName] {
+			t.Errorf("duplicate DisplayName %q", e.DisplayName)
+		}
+
+		seen[e.DisplayName] = true
 	}
 }
 


### PR DESCRIPTION
## Summary

The `ipscout config` display was 250+ lines of hand-copied per-provider blocks, one stanza per provider, with nothing keeping it in sync with the provider registry. As a result it had silently drifted — several providers were missing from the output entirely. This replaces those blocks with a single loop over `registry.All()` so every registered provider appears automatically and can never be silently omitted again.

While here, it also enables host rating for the GoogleSC provider, which had live `RateHostData` scoring code but was left disabled (the same half-wired pattern recently fixed for the hosting providers).

## What was broken

`ipscout config` was missing **four** providers from its output despite them being fully registered and configurable:

- Azure WAF
- Bingbot
- Google Special-case Crawlers
- IPQualityScore

(Alibaba had also been missing until the previous change patched it by hand — exactly the kind of omission this refactor makes structurally impossible.)

## Changes

- **registry**: add a `DisplayName` field to `Entry`, populated for every provider. The registry is already the single source of truth used by `process` and `rate`; this extends it to the config display too.
- **config**: replace the per-provider blocks with a registry-driven loop. `config.go` drops from 449 to ~196 lines. The two providers with extra list fields (Annotated `paths`, IPURL `urls`) are handled with a small `switch`.
- **GoogleSC rating**: flip `SupportsRating` to `true` and add a default rating-config entry. As a web crawler it gets a low benign score of `1.0`, matching Googlebot. (The other two disabled providers, `azurewaf` and `ptr`, were confirmed to have stub `RateHostData` and are correctly left off.)
- **tests**: assert every registry entry has a unique, non-empty `DisplayName` (guardrail against a future provider rendering with a blank header); update `SupportsRating` expectations; assert the new GoogleSC default score.

## Verification

- `go build ./...`, `go vet`, full `go test ./...` all pass
- `gofmt` clean; `golangci-lint run` reports 0 issues
- Ran the built binary: `ipscout config show` now renders all 27 providers, including the four previously missing, with the `urls`/`paths` fields intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmLJYx1jD5wJLzAwQyhpV7)_