### PR TITLE
docs: correct RIPE-stat comment in alibaba network test

### DIFF
--- a/providers/alibaba/alibaba_network_test.go
+++ b/providers/alibaba/alibaba_network_test.go
@@ -43,8 +43,9 @@ func mockHTTPClient(status int, body []byte) *retryablehttp.Client {
 }
 
 // newMockedClient wires a ProviderClient to a mocked HTTP client serving the
-// upstream RIPE stat fixture (the primary bgpview source), plus a real temp
-// cache, with UseTestData off.
+// upstream RIPE stat fixture (now the primary source in the shared bgpview
+// fetcher, with BGPView as fallback), plus a real temp cache, with UseTestData
+// off.
 func newMockedClient(t *testing.T, status int, body []byte) *ProviderClient {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Follow-up to #102. Addresses the one Copilot review comment left on that PR: the `newMockedClient` doc comment in `providers/alibaba/alibaba_network_test.go` still described the mocked fixture as "the primary bgpview source" after the fixture had been switched to the RIPE stat response shape.

Reworded to reflect that RIPE stat is now the primary source in the shared bgpview fetcher, with BGPView as the fallback. Comment-only change — no behaviour impact.

## On the Codacy gate (for context)

#102's Codacy "Static Code Analysis" gate reported 5 medium ErrorProne issues. I was unable to reproduce them: `gosec`, `staticcheck`, `revive`, `gocritic` (diagnostic group) and the full repo `golangci-lint` all report **zero** issues on the new and modified code, and Codacy's per-issue detail is only in its (auth-gated) dashboard with no inline annotations. The dominant gate signal is duplication, which is inherent to the templated provider packages (they mirror the existing providers' structure). Happy to address the 5 specific findings if the list can be shared.

## Verification

- `go test ./providers/alibaba/...` passes
- `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NmLJYx1jD5wJLzAwQyhpV7)_