### PR TITLE
refactor(rate): inject OpenAI client via a ChatCompleter seam

### DIFF
--- a/rate/rate.go
+++ b/rate/rate.go
@@ -83,8 +83,15 @@ func getEnabledProviders(runners map[string]providers.ProviderClient) map[string
 	return res
 }
 
+// ChatCompleter is the subset of the OpenAI client used for AI rating. It lets
+// the completion backend be injected so the rating flow can be tested offline.
+type ChatCompleter interface {
+	CreateChatCompletion(context.Context, openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error)
+}
+
 type Rater struct {
-	Session *session.Session
+	Session  *session.Session
+	AIClient ChatCompleter
 }
 
 func GetRatingConfig(path string) ([]byte, error) {
@@ -213,7 +220,10 @@ func aiRate(r *Rater, enabledProviders map[string]providers.ProviderClient, resu
 		},
 	})
 
-	client := openai.NewClient(r.Session.Config.Rating.OpenAIAPIKey)
+	client := r.AIClient
+	if client == nil {
+		client = openai.NewClient(r.Session.Config.Rating.OpenAIAPIKey)
+	}
 
 	resp, err := client.CreateChatCompletion(
 		context.Background(),
@@ -557,7 +567,8 @@ func findHosts(runners map[string]providers.ProviderClient, hideProgress bool) *
 
 func New(sess *session.Session) (Rater, error) {
 	p := Rater{
-		Session: sess,
+		Session:  sess,
+		AIClient: openai.NewClient(sess.Config.Rating.OpenAIAPIKey),
 	}
 
 	return p, nil

--- a/rate/rate_ai_test.go
+++ b/rate/rate_ai_test.go
@@ -1,0 +1,72 @@
+package rate
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/jonhadfield/ipscout/providers"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeCompleter is an injectable ChatCompleter that returns a canned response,
+// so aiRate can be exercised without calling OpenAI.
+type fakeCompleter struct {
+	resp openai.ChatCompletionResponse
+	err  error
+}
+
+func (f fakeCompleter) CreateChatCompletion(_ context.Context, _ openai.ChatCompletionRequest) (openai.ChatCompletionResponse, error) {
+	return f.resp, f.err
+}
+
+func newRaterWithCompleter(t *testing.T, c ChatCompleter) *Rater {
+	t.Helper()
+
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+
+	return &Rater{
+		Session:  &session.Session{Logger: lg, Stats: session.CreateStats()},
+		AIClient: c,
+	}
+}
+
+func emptyResults() *findHostsResults {
+	return &findHostsResults{m: map[string][]byte{}}
+}
+
+func TestAIRateSuccess(t *testing.T) {
+	t.Parallel()
+
+	r := newRaterWithCompleter(t, fakeCompleter{
+		resp: openai.ChatCompletionResponse{
+			Choices: []openai.ChatCompletionChoice{
+				{Message: openai.ChatCompletionMessage{Content: "recommend blocking"}},
+			},
+		},
+	})
+
+	require.NoError(t, aiRate(r, map[string]providers.ProviderClient{}, emptyResults()))
+}
+
+func TestAIRateNoChoices(t *testing.T) {
+	t.Parallel()
+
+	r := newRaterWithCompleter(t, fakeCompleter{resp: openai.ChatCompletionResponse{}})
+
+	err := aiRate(r, map[string]providers.ProviderClient{}, emptyResults())
+	require.ErrorContains(t, err, "no choices")
+}
+
+func TestAIRateCompletionError(t *testing.T) {
+	t.Parallel()
+
+	r := newRaterWithCompleter(t, fakeCompleter{err: errors.New("api down")})
+
+	err := aiRate(r, map[string]providers.ProviderClient{}, emptyResults())
+	require.ErrorContains(t, err, "api down")
+}


### PR DESCRIPTION
## What

`aiRate` constructed the OpenAI client inline (`openai.NewClient(...)`), so the AI rating flow couldn't be tested without a live API key — it was the main reason `rate` stayed low-coverage.

This introduces a small dependency-injection seam:
- A `ChatCompleter` interface (the one method `aiRate` uses), satisfied by `*openai.Client`.
- An injectable `AIClient ChatCompleter` field on `Rater`, defaulted in `New()`.
- `aiRate` uses `r.AIClient`, falling back to a real client when unset (so any direct `Rater{}` construction still works).

## Why

It unlocks offline testing of the AI rating path and makes the OpenAI dependency swappable. No behaviour change for the CLI.

## Tests

`rate_ai_test.go` covers `aiRate`'s success, no-choices, and completion-error paths with a fake completer. `rate` coverage 40.4% → 47.0%.

- [x] `go build ./...`
- [x] `go test ./rate/` passes
- [x] `golangci-lint run ./rate/` → 0 issues