### PR TITLE
chore: drop logrus, standardise on slog

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,7 +13,6 @@ import (
 	c "github.com/jonhadfield/ipscout/constants"
 	"github.com/jonhadfield/ipscout/process"
 	"github.com/jonhadfield/ipscout/session"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -843,22 +842,18 @@ func initLogging(cmd *cobra.Command) error {
 	switch strings.ToUpper(ll) {
 	case "ERROR":
 		ProgramLevel.Set(slog.LevelError)
-		logrus.SetLevel(logrus.ErrorLevel)
 
 		sess.HideProgress = false
 	case "WARN":
 		ProgramLevel.Set(slog.LevelWarn)
-		logrus.SetLevel(logrus.WarnLevel)
 
 		sess.HideProgress = false
 	case "INFO":
 		ProgramLevel.Set(slog.LevelInfo)
-		logrus.SetLevel(logrus.InfoLevel)
 
 		sess.HideProgress = true
 	case "DEBUG":
 		ProgramLevel.Set(slog.LevelDebug)
-		logrus.SetLevel(logrus.DebugLevel)
 
 		sess.HideProgress = true
 	}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/rivo/tview v0.42.0
 	github.com/sashabaranov/go-openai v1.41.2
-	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -85,6 +84,7 @@ require (
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
+	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/ui/root.go
+++ b/ui/root.go
@@ -10,7 +10,6 @@ import (
 	h "github.com/jonhadfield/ipscout/helpers"
 
 	"github.com/jonhadfield/ipscout/session"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -539,22 +538,18 @@ func initLogging() error {
 	switch strings.ToUpper(ll) {
 	case "ERROR":
 		ProgramLevel.Set(slog.LevelError)
-		logrus.SetLevel(logrus.ErrorLevel)
 
 		sess.HideProgress = false
 	case "WARN":
 		ProgramLevel.Set(slog.LevelWarn)
-		logrus.SetLevel(logrus.WarnLevel)
 
 		sess.HideProgress = false
 	case "INFO":
 		ProgramLevel.Set(slog.LevelInfo)
-		logrus.SetLevel(logrus.InfoLevel)
 
 		sess.HideProgress = true
 	case "DEBUG":
 		ProgramLevel.Set(slog.LevelDebug)
-		logrus.SetLevel(logrus.DebugLevel)
 
 		sess.HideProgress = true
 	}


### PR DESCRIPTION
## What

`cmd/root.go` and `ui/root.go` were the only files still importing `sirupsen/logrus`, and they only called `logrus.SetLevel(...)`. Those calls were vestigial: the application logs through `slog`, and each switch case already sets the real level via `ProgramLevel.Set(...)` (which backs `sess.Logger`) right next to the logrus call.

This removes the dead `SetLevel` calls and the import. `go mod tidy` demotes `logrus` from a direct to an indirect dependency (it remains transitively).

## Why

One logging framework instead of two — no second config surface, no confusion about which level applies. No behaviour change (the slog level handling is untouched).

## Verification

- [x] no `sirupsen/logrus` references remain in code
- [x] `go build ./...`
- [x] `go test ./cmd/ ./ui/` pass
- [x] `golangci-lint run ./cmd/ ./ui/` → 0 issues