### PR TITLE
chore: pin ip-fetcher to release tag v0.0.16 (was pseudo-version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ go build ./...
 
 This will create an `ipscout` binary in the current directory.
 
+### Updating the ip-fetcher dependency
+
+Most providers source their IP-range data via [`ip-fetcher`](https://github.com/jonhadfield/ip-fetcher). It is pinned in `go.mod` to a `v`-prefixed release tag — that released module, not a local checkout, is the source of truth for upstream data formats. To pick up changes:
+
+1. Cut a new `v`-prefixed release tag in the ip-fetcher repo (e.g. `v0.0.17`).
+2. In this repo: `go get github.com/jonhadfield/ip-fetcher@vX.Y.Z && go mod tidy`.
+
+The commented `replace` directive in `go.mod` is for local development only and must never be committed enabled.
+
 ## Usage
 
 ```shell

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/jedib0t/go-pretty/v6 v6.8.1
 	github.com/jonhadfield/azwaf v0.2.0
-	github.com/jonhadfield/ip-fetcher v0.0.0-20260627105022-9e75d8e69c51
+	github.com/jonhadfield/ip-fetcher v0.0.16
 	github.com/miekg/dns v1.1.72
 	github.com/rivo/tview v0.42.0
 	github.com/sashabaranov/go-openai v1.41.2
@@ -26,6 +26,12 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+// ip-fetcher is pinned to a v-prefixed release tag above (not a pseudo-version).
+// That released module — NOT a local ../ip-fetcher checkout — is the source of
+// truth for upstream data formats (e.g. BGP-based providers fetch BGPView-first
+// in the released version). Uncomment the replace below only for local dev, and
+// never commit it enabled. Cut a new ip-fetcher release tag and bump the version
+// above when picking up ip-fetcher changes.
 // replace github.com/jonhadfield/ip-fetcher => ../ip-fetcher
 
 // replace github.com/jonhadfield/azwaf => ../azwaf

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/jonhadfield/azwaf v0.2.0 h1:Rqd4Y7kJhn9KZ5JJPbwLcnVHoG7xlqQdmAwMOT8pf
 github.com/jonhadfield/azwaf v0.2.0/go.mod h1:cxtKTBDDzhqPnoPqNTKiwjQP/xs2UAGlOF4wGYiN1qk=
 github.com/jonhadfield/findexec v0.0.0-20190902195615-78db24cd4e77 h1:U1mtIepXhvIq0cLDLO6z1hZYS80lDXzmsZJwMgzwaf8=
 github.com/jonhadfield/findexec v0.0.0-20190902195615-78db24cd4e77/go.mod h1:9Q9pFtVLzvgKEi8++fNhmSR7HpD9+9+dPy/SECsNB6k=
-github.com/jonhadfield/ip-fetcher v0.0.0-20260627105022-9e75d8e69c51 h1:ihmra/DrJglG7KdLD5pn+/r5rndKXu70SCai1YCfwRY=
-github.com/jonhadfield/ip-fetcher v0.0.0-20260627105022-9e75d8e69c51/go.mod h1:78UDnQ9/YJ8r1IeaUOqpN48HWNnHppPk2Hkbx6Cfhk8=
+github.com/jonhadfield/ip-fetcher v0.0.16 h1:FzcQJho9N7aio4wT3kY9j+T8I67w+rrRDR/cBpki2Dk=
+github.com/jonhadfield/ip-fetcher v0.0.16/go.mod h1:78UDnQ9/YJ8r1IeaUOqpN48HWNnHppPk2Hkbx6Cfhk8=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=


### PR DESCRIPTION
## What

`go.mod` pinned `ip-fetcher` to a **pseudo-version** (`v0.0.0-20260627105022-9e75d8e69c51`) because the dependency had no `v`-prefixed module tags (its existing tags were `0.0.x`, which Go modules can't consume). This bumps it to a proper release tag.

- Created tag **`v0.0.16`** on `ip-fetcher` at commit `9e75d8e` — which is exactly the tip of `ip-fetcher` `main` and the same commit ipscout already pinned. So this bump is **code-neutral**: identical code, clean version string.
- `go get ...@v0.0.16 && go mod tidy` updated `go.mod`/`go.sum`.
- Documented the coupling in `go.mod` (at the `replace` directive) and `README.md` so future updates cut a release tag instead of another pseudo-version.

## Why

The pseudo-version pointed at a bare commit and was easy to confuse with a local `../ip-fetcher` checkout, which can differ in upstream fetch behaviour (BGP providers fetch BGPView-first in the released version) — this caused real confusion during the network-test work. A tagged release makes the dependency reference stable and self-documenting.

## Verification

- [x] `go build ./...`
- [x] full test suite passes unchanged (bump is code-neutral)
- [x] `golangci-lint run ./...` → 0 issues