### PR TITLE
chore: raise coverage gate floor to 59% after new providers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         # coverage improves so it can only move up. Linux-only to avoid duplication.
         if: runner.os == 'Linux'
         env:
-          MIN_COVERAGE: "55.0"
+          MIN_COVERAGE: "59.0"
         run: |
           total=$(go tool cover -func=cover.out | awk '/^total:/ {gsub(/%/,"",$3); print $3}')
           echo "total coverage: ${total}% (minimum: ${MIN_COVERAGE}%)"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ cover: test
 
 # Ratchet gate: fail if total statement coverage drops below MIN_COVERAGE.
 # Raise MIN_COVERAGE as coverage improves so it can only move up.
-MIN_COVERAGE?=55.0
+MIN_COVERAGE?=59.0
 cover-check:
 	@total=$$(go tool cover -func=coverage.txt | awk '/^total:/ {gsub(/%/,"",$$3); print $$3}'); \
 	echo "total coverage: $$total% (minimum: $(MIN_COVERAGE)%)"; \


### PR DESCRIPTION
## What

Raises the coverage ratchet gate floor **55.0 → 59.0** in `make cover-check` and the CI step.

## Why

Total statement coverage is now **60.4%** (measured on `main`). The 12 new ip-fetcher providers shipped with their own tests, and the host-rating + config-registry changes added coverage, so the previous 55% floor no longer reflects reality. Bumping it locks in the gains; the ~1.4% margin below the measured total absorbs cross-platform/rounding variance.

## Verification

- [x] measured total = 60.4% ≥ 59.0% floor