### PR TITLE
fix: wire newer providers into initProviderConfig

### DIFF
--- a/cmd/provider_wiring_test.go
+++ b/cmd/provider_wiring_test.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/jonhadfield/ipscout/registry"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAllRegistryProvidersWiredIntoConfig guards against the class of bug where
+// a provider is added to the registry but not wired into initProviderConfig, so
+// its Enabled flag is never read from config and process silently skips it.
+func TestAllRegistryProvidersWiredIntoConfig(t *testing.T) {
+	v := viper.New()
+	for _, e := range registry.All() {
+		v.Set("providers."+e.Name+".enabled", true)
+	}
+
+	sess := session.New()
+	initProviderConfig(sess, v)
+
+	for _, e := range registry.All() {
+		enabled := e.Enabled(*sess)
+		require.NotNilf(t, enabled, "provider %q is in the registry but not wired into initProviderConfig", e.Name)
+		require.Truef(t, *enabled, "provider %q enabled flag was not read from config", e.Name)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -689,6 +689,50 @@ func initProviderConfig(sess *session.Session, v *viper.Viper) {
 
 	sess.Providers.Zscaler.DocumentCacheTTL = v.GetInt64("providers.zscaler.document_cache_ttl")
 	sess.Providers.Zscaler.URL = v.GetString("providers.zscaler.url")
+
+	initSimpleProviderConfig(sess, v, "atlassian", "Atlassian", c.DefaultAtlassianOutputPriority,
+		&sess.Providers.Atlassian.Enabled, &sess.Providers.Atlassian.OutputPriority, &sess.Providers.Atlassian.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "bunny", "Bunny CDN", c.DefaultBunnyOutputPriority,
+		&sess.Providers.Bunny.Enabled, &sess.Providers.Bunny.OutputPriority, &sess.Providers.Bunny.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "cdn77", "CDN77", c.DefaultCDN77OutputPriority,
+		&sess.Providers.CDN77.Enabled, &sess.Providers.CDN77.OutputPriority, &sess.Providers.CDN77.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "contabo", "Contabo", c.DefaultContaboOutputPriority,
+		&sess.Providers.Contabo.Enabled, &sess.Providers.Contabo.OutputPriority, &sess.Providers.Contabo.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "datadog", "Datadog", c.DefaultDatadogOutputPriority,
+		&sess.Providers.Datadog.Enabled, &sess.Providers.Datadog.OutputPriority, &sess.Providers.Datadog.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "flyio", "Fly.io", c.DefaultFlyioOutputPriority,
+		&sess.Providers.Flyio.Enabled, &sess.Providers.Flyio.OutputPriority, &sess.Providers.Flyio.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "ibmcloud", "IBM Cloud", c.DefaultIBMCloudOutputPriority,
+		&sess.Providers.IBMCloud.Enabled, &sess.Providers.IBMCloud.OutputPriority, &sess.Providers.IBMCloud.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "imperva", "Imperva", c.DefaultImpervaOutputPriority,
+		&sess.Providers.Imperva.Enabled, &sess.Providers.Imperva.OutputPriority, &sess.Providers.Imperva.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "leaseweb", "Leaseweb", c.DefaultLeasewebOutputPriority,
+		&sess.Providers.Leaseweb.Enabled, &sess.Providers.Leaseweb.OutputPriority, &sess.Providers.Leaseweb.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "render", "Render", c.DefaultRenderOutputPriority,
+		&sess.Providers.Render.Enabled, &sess.Providers.Render.OutputPriority, &sess.Providers.Render.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "stripe", "Stripe", c.DefaultStripeOutputPriority,
+		&sess.Providers.Stripe.Enabled, &sess.Providers.Stripe.OutputPriority, &sess.Providers.Stripe.DocumentCacheTTL)
+	initSimpleProviderConfig(sess, v, "tencent", "Tencent Cloud", c.DefaultTencentOutputPriority,
+		&sess.Providers.Tencent.Enabled, &sess.Providers.Tencent.OutputPriority, &sess.Providers.Tencent.DocumentCacheTTL)
+}
+
+// initSimpleProviderConfig wires a provider with the common enabled /
+// output_priority / document_cache_ttl config shape into the session, so that
+// providers registered in the registry are actually read from config.
+func initSimpleProviderConfig(sess *session.Session, v *viper.Viper, key, displayName string, defaultPriority int32, enabled **bool, priority **int32, docCacheTTL *int64) {
+	if v.IsSet("providers." + key + ".enabled") {
+		*enabled = ToPtr(v.GetBool("providers." + key + ".enabled"))
+	} else {
+		addProviderConfigMessage(sess, displayName)
+	}
+
+	if v.IsSet("providers." + key + ".output_priority") {
+		*priority = ToPtr(v.GetInt32("providers." + key + ".output_priority"))
+	} else {
+		*priority = ToPtr(defaultPriority)
+	}
+
+	*docCacheTTL = v.GetInt64("providers." + key + ".document_cache_ttl")
 }
 
 func initHomeDirConfig(sess *session.Session, v *viper.Viper) error {

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -62,9 +62,21 @@ const DefaultZscalerOutputPriority = 40
 const (
 	DefaultAbuseIPDBOutputPriority  = 50
 	DefaultAnnotatedOutputPriority  = 30
+	DefaultAtlassianOutputPriority  = 60
 	DefaultAWSOutputPriority        = 200
 	DefaultAzureOutputPriority      = 200
 	DefaultAzureWAFOutputPriority   = 20
 	DefaultBingbotOutputPriority    = 180
+	DefaultBunnyOutputPriority      = 140
+	DefaultCDN77OutputPriority      = 140
+	DefaultContaboOutputPriority    = 140
 	DefaultCriminalIPOutputPriority = 60
+	DefaultDatadogOutputPriority    = 60
+	DefaultFlyioOutputPriority      = 140
+	DefaultIBMCloudOutputPriority   = 200
+	DefaultImpervaOutputPriority    = 20
+	DefaultLeasewebOutputPriority   = 140
+	DefaultRenderOutputPriority     = 140
+	DefaultStripeOutputPriority     = 60
+	DefaultTencentOutputPriority    = 200
 )

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8
 	github.com/jedib0t/go-pretty/v6 v6.8.1
 	github.com/jonhadfield/azwaf v0.2.0
-	github.com/jonhadfield/ip-fetcher v0.0.17
+	github.com/jonhadfield/ip-fetcher v0.0.18
 	github.com/miekg/dns v1.1.72
 	github.com/rivo/tview v0.42.0
 	github.com/sashabaranov/go-openai v1.41.2

--- a/go.sum
+++ b/go.sum
@@ -218,8 +218,8 @@ github.com/jonhadfield/azwaf v0.2.0 h1:Rqd4Y7kJhn9KZ5JJPbwLcnVHoG7xlqQdmAwMOT8pf
 github.com/jonhadfield/azwaf v0.2.0/go.mod h1:cxtKTBDDzhqPnoPqNTKiwjQP/xs2UAGlOF4wGYiN1qk=
 github.com/jonhadfield/findexec v0.0.0-20190902195615-78db24cd4e77 h1:U1mtIepXhvIq0cLDLO6z1hZYS80lDXzmsZJwMgzwaf8=
 github.com/jonhadfield/findexec v0.0.0-20190902195615-78db24cd4e77/go.mod h1:9Q9pFtVLzvgKEi8++fNhmSR7HpD9+9+dPy/SECsNB6k=
-github.com/jonhadfield/ip-fetcher v0.0.17 h1:xD66AaoQXI/p4KHLrD97dd9OfNOXL+ZudmFR3KvsCjM=
-github.com/jonhadfield/ip-fetcher v0.0.17/go.mod h1:78UDnQ9/YJ8r1IeaUOqpN48HWNnHppPk2Hkbx6Cfhk8=
+github.com/jonhadfield/ip-fetcher v0.0.18 h1:Nrib9oWnyNt+xSms5LWgohxQtV/bWkIC4tsmwjWZRxQ=
+github.com/jonhadfield/ip-fetcher v0.0.18/go.mod h1:78UDnQ9/YJ8r1IeaUOqpN48HWNnHppPk2Hkbx6Cfhk8=
 github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE=
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=


### PR DESCRIPTION
The 12 providers added recently (atlassian, bunny, cdn77, contabo, datadog, flyio, ibmcloud, imperva, leaseweb, render, stripe, tencent) were in the registry and enabled in the default config, but `initProviderConfig` never read their settings — their `Enabled` flag stayed nil, so `ipscout` silently skipped them.

- Wires all 12 via a new `initSimpleProviderConfig` helper (enabled / output_priority / document_cache_ttl — the common shape they all share), with category-based default priorities (clouds 200, hosting/CDN 140, SaaS 60, WAF 20).
- Adds a registry-driven test (`TestAllRegistryProvidersWiredIntoConfig`) so a provider registered but not wired fails CI instead of silently vanishing.
- Bumps ip-fetcher to [v0.0.18](https://github.com/jonhadfield/ip-fetcher/releases/tag/v0.0.18): activating the providers exposed that atlassian and cdn77 had never worked against their live feeds (numeric `syncToken`; unhandled feed shape) — fixed upstream in jonhadfield/ip-fetcher#107.

Verified live: all 12 providers initialise with no errors; `ipscout 52.82.172.1` → Atlassian match, `ipscout 89.222.125.1` → CDN77 match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)