### PR TITLE
feat: enable no-config providers by default and add IPtoASN provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Provider data and search results can be cached to reduce API calls and improve p
 | [Imperva](#Imperva)                                       |       WAF        |           -           |
 | [IPAPI](#IPAPI)                                           |  IP Geolocation  |           -           |
 | [IPQualityScore](#IPQualityScore)                         |  IP Reputation   | Registration required |
+| [IPtoASN](#IPtoASN)                                       |     ASN Data     |           -           |
 | [IPURL](#IPURL)                                           |  User Provided   |           -           |
 | [Leaseweb](#Leaseweb)                                     | Hosting Provider |           -           |
 | [Linode](#Linode)                                         | Hosting Provider |           -           |
@@ -312,6 +313,12 @@ Query the [IPQualityScore](https://www.ipqualityscore.com/documentation/proxy-de
 The API is free to registered users for 5,000 requests.
 
 Set environment variable `IPQS_API_KEY` with your API key.
+
+### IPtoASN
+
+[iptoasn.com](https://iptoasn.com/) publishes a free, hourly-updated IP address to ASN mapping.
+The combined IPv4+IPv6 dataset is downloaded and cached, and the target host is matched against it to report the
+announcing AS number, name, country and address range.
 
 ### IPURL
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -35,7 +35,7 @@ var (
 )
 
 func Create(logger *slog.Logger, path string) (*badger.DB, error) {
-	logger.Info("creating cache", "path", filepath.Join(path, "cache"))
+	logger.Debug("creating cache", "path", filepath.Join(path, "cache"))
 
 	if path == "" {
 		return nil, errors.New("path is empty")
@@ -66,7 +66,7 @@ func UpsertWithTTL(logger *slog.Logger, db *badger.DB, item Item, ttl time.Durat
 		return fmt.Errorf("error marshalling cache item: %w", err)
 	}
 
-	logger.Info("upserting item", "key", item.Key, "value len", len(mItem), "ttl", ttl.String())
+	logger.Debug("upserting item", "key", item.Key, "value len", len(mItem), "ttl", ttl.String())
 
 	if int64(len(mItem)) > db.Opts().ValueLogFileSize {
 		return fmt.Errorf("cache value too large for key %s: %d bytes exceeds %d byte limit",
@@ -140,7 +140,7 @@ func CheckExists(logger *slog.Logger, db *badger.DB, key string) (bool, error) {
 }
 
 func Delete(logger *slog.Logger, db *badger.DB, key string) error {
-	logger.Info("deleting cache item", "key", key)
+	logger.Debug("deleting cache item", "key", key)
 
 	if err := db.Update(func(txn *badger.Txn) error {
 		return txn.Delete([]byte(key))
@@ -152,7 +152,7 @@ func Delete(logger *slog.Logger, db *badger.DB, key string) error {
 }
 
 func DeleteMultiple(logger *slog.Logger, db *badger.DB, keys []string) error {
-	logger.Info("deleting cache items", "keys", keys)
+	logger.Debug("deleting cache items", "keys", keys)
 
 	var deletedKeys []string
 

--- a/cmd/provider_wiring_test.go
+++ b/cmd/provider_wiring_test.go
@@ -27,3 +27,35 @@ func TestAllRegistryProvidersWiredIntoConfig(t *testing.T) {
 		require.Truef(t, *enabled, "provider %q enabled flag was not read from config", e.Name)
 	}
 }
+
+// TestNoConfigProvidersEnabledByDefault guards the promise that providers
+// requiring no configuration are enabled even when absent from the user's
+// config file, while providers that need config (API keys, paths, URLs,
+// resource IDs) stay unset so process skips them.
+func TestNoConfigProvidersEnabledByDefault(t *testing.T) {
+	sess := session.New()
+	initProviderConfig(sess, viper.New())
+
+	for _, e := range registry.All() {
+		enabled := e.Enabled(*sess)
+		if e.DefaultEnabled {
+			require.NotNilf(t, enabled, "no-config provider %q should be enabled by default", e.Name)
+			require.Truef(t, *enabled, "no-config provider %q should be enabled by default", e.Name)
+		} else {
+			require.Nilf(t, enabled, "provider %q requires config and must not be enabled by default", e.Name)
+		}
+	}
+}
+
+// TestExplicitDisableOverridesDefaultEnabled ensures a user's explicit
+// enabled=false still wins over the no-config default.
+func TestExplicitDisableOverridesDefaultEnabled(t *testing.T) {
+	v := viper.New()
+	v.Set("providers.aws.enabled", false)
+
+	sess := session.New()
+	initProviderConfig(sess, v)
+
+	require.NotNil(t, sess.Providers.AWS.Enabled)
+	require.False(t, *sess.Providers.AWS.Enabled)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -646,6 +646,22 @@ func initProviderConfig(sess *session.Session, v *viper.Viper) {
 		sess.Providers.IPAPI.OutputPriority = ToPtr(int32(defaultIPAPIOutputPriority))
 	}
 
+	// IPtoASN
+	if v.IsSet("providers.iptoasn.enabled") {
+		sess.Providers.IPToASN.Enabled = ToPtr(v.GetBool("providers.iptoasn.enabled"))
+	} else {
+		addProviderConfigMessage(sess, "IPtoASN")
+	}
+
+	if v.IsSet("providers.iptoasn.output_priority") {
+		sess.Providers.IPToASN.OutputPriority = ToPtr(v.GetInt32("providers.iptoasn.output_priority"))
+	} else {
+		sess.Providers.IPToASN.OutputPriority = ToPtr(int32(c.DefaultIPToASNOutputPriority))
+	}
+
+	sess.Providers.IPToASN.URL = v.GetString("providers.iptoasn.url")
+	sess.Providers.IPToASN.DocumentCacheTTL = v.GetInt64("providers.iptoasn.document_cache_ttl")
+
 	// VirusTotal
 	if v.IsSet("providers.virustotal.enabled") {
 		sess.Providers.VirusTotal.Enabled = ToPtr(v.GetBool("providers.virustotal.enabled"))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/jonhadfield/ipscout/helpers"
@@ -801,6 +802,14 @@ func initConfig(cmd *cobra.Command) error {
 
 	if _, err := session.CreateDefaultConfigIfMissing(configRoot); err != nil {
 		return fmt.Errorf("cannot create default session: %w", err)
+	}
+
+	// add any providers introduced since the user's config was written, so
+	// their config shows all no-config providers as enabled
+	if _, err := registry.EnsureDefaultProvidersInConfig(filepath.Join(configRoot, session.DefaultConfigFileName)); err != nil {
+		sess.Messages.Mu.Lock()
+		sess.Messages.Info = append(sess.Messages.Info, fmt.Sprintf("unable to add new providers to config: %s", err))
+		sess.Messages.Mu.Unlock()
 	}
 
 	v.AddConfigPath(configRoot)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,7 @@ import (
 
 	c "github.com/jonhadfield/ipscout/constants"
 	"github.com/jonhadfield/ipscout/process"
+	"github.com/jonhadfield/ipscout/registry"
 	"github.com/jonhadfield/ipscout/session"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -238,6 +239,10 @@ const (
 )
 
 func initProviderConfig(sess *session.Session, v *viper.Viper) {
+	// providers requiring no configuration default to enabled when absent
+	// from the user's config file
+	registry.SetEnabledDefaults(v)
+
 	// IP API
 	sess.Providers.IPAPI.APIKey = v.GetString("providers.ipapi.api_key")
 	sess.Providers.IPAPI.ResultCacheTTL = v.GetInt64("providers.ipapi.result_cache_ttl")

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -41,6 +41,8 @@ const DefaultiCloudPROutputPriority = 100
 
 const DefaultIPAPIOutputPriority = 90
 
+const DefaultIPToASNOutputPriority = 90
+
 const DefaultIPQSOutputPriority = 50
 
 const DefaultIPURLOutputPriority = 20

--- a/process/process.go
+++ b/process/process.go
@@ -264,7 +264,12 @@ func findHosts(runners map[string]providers.ProviderClient, hideProgress bool) *
 
 			result, err := runner.FindHost()
 			if err != nil {
-				runner.GetConfig().Logger.Info(err.Error())
+				// a host not appearing in a provider's data is routine
+				if errors.Is(err, providers.ErrNoMatchFound) {
+					runner.GetConfig().Logger.Debug(err.Error())
+				} else {
+					runner.GetConfig().Logger.Info(err.Error())
+				}
 
 				return
 			}

--- a/providers/azure/azure.go
+++ b/providers/azure/azure.go
@@ -206,7 +206,7 @@ func loadTestData(c *ProviderClient) ([]byte, error) {
 		return nil, fmt.Errorf("error marshalling test data: %w", err)
 	}
 
-	c.Logger.Info("azure match returned from test data", "host", c.Host.String())
+	c.Logger.Debug("azure match returned from test data", "host", c.Host.String())
 
 	return out, nil
 }
@@ -269,7 +269,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 		return nil, err
 	}
 
-	c.Logger.Info("azure match found", "host", c.Host.String())
+	c.Logger.Debug("azure match found", "host", c.Host.String())
 
 	var raw []byte
 

--- a/providers/azurewaf/azurewaf.go
+++ b/providers/azurewaf/azurewaf.go
@@ -230,7 +230,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 			return nil, loadErr
 		}
 
-		c.Logger.Info("azure waf match returned from test data", "host", c.Host.String())
+		c.Logger.Debug("azure waf match returned from test data", "host", c.Host.String())
 
 		return out, nil
 	}
@@ -249,7 +249,7 @@ func (c *ProviderClient) FindHost() ([]byte, error) {
 		return nil, providers.ErrNoMatchFound
 	}
 
-	c.Logger.Info("azurewaf match found", "host", c.Host.String())
+	c.Logger.Debug("azurewaf match found", "host", c.Host.String())
 
 	var raw []byte
 

--- a/providers/iptoasn/iptoasn.go
+++ b/providers/iptoasn/iptoasn.go
@@ -1,0 +1,435 @@
+package iptoasn
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/netip"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jonhadfield/ipscout/helpers"
+
+	"github.com/jonhadfield/ipscout/constants"
+
+	"github.com/hashicorp/go-retryablehttp"
+
+	"github.com/jonhadfield/ipscout/providers"
+
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jonhadfield/ipscout/cache"
+	"github.com/jonhadfield/ipscout/session"
+)
+
+const (
+	ProviderName = "iptoasn"
+	DocTTL       = 24 * time.Hour
+	// DownloadURL is the combined IPv4+IPv6 ip-to-ASN dataset published by
+	// iptoasn.com; the JSON API is not used as it sits behind bot protection.
+	DownloadURL = "https://iptoasn.com/data/ip2asn-combined.tsv.gz"
+
+	notRoutedDescription = "Not routed"
+	tsvFieldCount        = 5
+)
+
+type Client struct {
+	session.Session
+}
+
+type Config struct {
+	_ struct{}
+	session.Session
+	Host netip.Addr
+}
+
+func NewProviderClient(c session.Session) (providers.ProviderClient, error) {
+	c.Logger.Debug("creating iptoasn client")
+
+	tc := Client{
+		c,
+	}
+
+	return &tc, nil
+}
+
+type Provider interface {
+	LoadData() ([]byte, error)
+	CreateTable([]byte) (*table.Writer, error)
+}
+
+func (c *Client) Enabled() bool {
+	if c.UseTestData || (c.Providers.IPToASN.Enabled != nil && *c.Providers.IPToASN.Enabled) {
+		return true
+	}
+
+	return false
+}
+
+func (c *Client) Priority() *int32 {
+	return c.Providers.IPToASN.OutputPriority
+}
+
+func (c *Client) GetConfig() *session.Session {
+	return &c.Session
+}
+
+func (c *Client) ExtractThreatIndicators(findRes []byte) (*providers.ThreatIndicators, error) {
+	var doc HostSearchResult
+
+	if err := json.Unmarshal(findRes, &doc); err != nil {
+		return nil, fmt.Errorf(constants.ErrUnmarshalFindResultFmt, err)
+	}
+
+	threatIndicators := providers.ThreatIndicators{
+		Provider: ProviderName,
+	}
+
+	indicators := make(map[string]string)
+
+	indicators["CountryCode"] = doc.ASCountryCode
+
+	threatIndicators.Indicators = indicators
+
+	return &threatIndicators, nil
+}
+
+func (c *Client) RateHostData(findRes []byte, ratingConfigJSON []byte) (providers.RateResult, error) {
+	var ratingConfig providers.RatingConfig
+	if err := json.Unmarshal(ratingConfigJSON, &ratingConfig); err != nil {
+		return providers.RateResult{}, fmt.Errorf(constants.ErrUnmarshalRatingConfigFmt, err)
+	}
+
+	var doc HostSearchResult
+
+	var rateResult providers.RateResult
+
+	if err := json.Unmarshal(findRes, &doc); err != nil {
+		return providers.RateResult{}, fmt.Errorf(constants.ErrUnmarshalFindResultFmt, err)
+	}
+
+	rateResult.Score = 0
+	rateResult.Detected = false
+
+	if doc.ASCountryCode != "" {
+		i := slices.Index(ratingConfig.Global.HighThreatCountryCodes, doc.ASCountryCode)
+		if i != -1 {
+			rateResult.Detected = true
+			rateResult.Score += 9
+			rateResult.Reasons = append(rateResult.Reasons, fmt.Sprintf("High Threat Country: %s", doc.ASCountryCode))
+		} else {
+			i := slices.Index(ratingConfig.Global.MediumThreatCountryCodes, doc.ASCountryCode)
+			if i != -1 {
+				rateResult.Detected = true
+				rateResult.Score += 7
+				rateResult.Reasons = append(rateResult.Reasons, fmt.Sprintf("Medium Threat Country: %s", doc.ASCountryCode))
+			}
+		}
+	}
+
+	return rateResult, nil
+}
+
+func (c *Client) loadProviderDataFromSource() error {
+	downloadURL := DownloadURL
+	if c.Providers.IPToASN.URL != "" {
+		downloadURL = c.Providers.IPToASN.URL
+		c.Logger.Debug("overriding iptoasn source", "url", downloadURL)
+	}
+
+	req, err := retryablehttp.NewRequest(http.MethodGet, downloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("error creating iptoasn request: %w", err)
+	}
+
+	req.Header.Set("User-Agent", providers.DefaultUA)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error fetching iptoasn data: %w", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("iptoasn download failed: %s: %w", resp.Status, providers.ErrFailedToFetchData)
+	}
+
+	// store the gzipped TSV as-is; FindHost decompresses when scanning
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading iptoasn data: %w", err)
+	}
+
+	c.Logger.Debug("writing iptoasn provider data to cache", "size", len(data))
+
+	docCacheTTL := DocTTL
+	if c.Providers.IPToASN.DocumentCacheTTL != 0 {
+		docCacheTTL = time.Minute * time.Duration(c.Providers.IPToASN.DocumentCacheTTL)
+	}
+
+	if err = cache.UpsertWithTTL(c.Logger, c.Cache, cache.Item{
+		AppVersion: c.App.SemVer,
+		Key:        providers.CacheProviderPrefix + ProviderName,
+		Value:      data,
+		Created:    time.Now(),
+	}, docCacheTTL); err != nil {
+		return fmt.Errorf("error writing iptoasn provider data to cache: %w", err)
+	}
+
+	return nil
+}
+
+func (c *Client) Initialise() error {
+	if c.Cache == nil {
+		return session.ErrCacheNotSet
+	}
+
+	defer helpers.TrackDuration(&c.Stats.Mu, c.Stats.InitialiseDuration, ProviderName)()
+
+	c.Logger.Debug("initialising iptoasn client")
+
+	if c.UseTestData {
+		return nil
+	}
+
+	ok, err := cache.CheckExists(c.Logger, c.Cache, providers.CacheProviderPrefix+ProviderName)
+	if err != nil {
+		return fmt.Errorf("error checking cache for iptoasn provider data: %w", err)
+	}
+
+	if ok {
+		c.Logger.Debug("iptoasn provider data found in cache")
+
+		return nil
+	}
+
+	return c.loadProviderDataFromSource()
+}
+
+func (c *Client) loadProviderDataFromCache() ([]byte, error) {
+	c.Logger.Debug("loading iptoasn provider data from cache")
+
+	cacheKey := providers.CacheProviderPrefix + ProviderName
+
+	item, err := cache.Read(c.Logger, c.Cache, cacheKey)
+	if err != nil {
+		return nil, fmt.Errorf("error reading iptoasn provider data from cache: %w", err)
+	}
+
+	c.Stats.Mu.Lock()
+	c.Stats.FindHostUsedCache[ProviderName] = true
+	c.Stats.Mu.Unlock()
+
+	return item.Value, nil
+}
+
+func (c *Client) FindHost() ([]byte, error) {
+	defer helpers.TrackDuration(&c.Stats.Mu, c.Stats.FindHostDuration, ProviderName)()
+
+	if c.UseTestData {
+		result, err := loadTestData(c.Logger)
+		if err != nil {
+			return nil, fmt.Errorf("error loading iptoasn test data: %w", err)
+		}
+
+		return result.Raw, nil
+	}
+
+	data, err := c.loadProviderDataFromCache()
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := matchHost(data, c.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling iptoasn result: %w", err)
+	}
+
+	c.Logger.Debug("iptoasn host match data", "size", len(raw))
+
+	return raw, nil
+}
+
+// matchHost scans the gzipped ip2asn TSV for the range containing host. Lines
+// are `first_ip<tab>last_ip<tab>as_number<tab>country_code<tab>description`,
+// sorted ascending within each address family (IPv4 ranges before IPv6), so
+// scanning stops as soon as the host's position is passed.
+func matchHost(gzData []byte, host netip.Addr) (*iptoasnResp, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(gzData))
+	if err != nil {
+		return nil, fmt.Errorf("error decompressing iptoasn data: %w", err)
+	}
+
+	defer gz.Close()
+
+	host = host.Unmap()
+
+	scanner := bufio.NewScanner(gz)
+	for scanner.Scan() {
+		fields := strings.SplitN(scanner.Text(), "\t", tsvFieldCount)
+		if len(fields) < tsvFieldCount {
+			continue
+		}
+
+		firstIP, err := netip.ParseAddr(fields[0])
+		if err != nil {
+			continue
+		}
+
+		if firstIP.Is4() != host.Is4() {
+			if host.Is4() && !firstIP.Is4() {
+				// passed the end of the IPv4 section
+				break
+			}
+
+			continue
+		}
+
+		if firstIP.Compare(host) > 0 {
+			// ranges are sorted, so the host cannot appear later
+			break
+		}
+
+		lastIP, err := netip.ParseAddr(fields[1])
+		if err != nil {
+			continue
+		}
+
+		if lastIP.Compare(host) < 0 {
+			continue
+		}
+
+		asNumber, err := strconv.ParseUint(fields[2], 10, 32)
+		if err != nil || asNumber == 0 || fields[4] == notRoutedDescription {
+			// hosts in unrouted ranges have no ASN details
+			break
+		}
+
+		return &iptoasnResp{
+			Announced:     true,
+			ASNumber:      uint32(asNumber),
+			ASCountryCode: fields[3],
+			ASDescription: fields[4],
+			FirstIP:       fields[0],
+			LastIP:        fields[1],
+			IP:            host.String(),
+		}, nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error scanning iptoasn data: %w", err)
+	}
+
+	return nil, fmt.Errorf("%s match failed: %w", ProviderName, providers.ErrNoMatchFound)
+}
+
+func (c *Client) CreateTable(data []byte) (*table.Writer, error) {
+	defer helpers.TrackDuration(&c.Stats.Mu, c.Stats.CreateTableDuration, ProviderName)()
+
+	if data == nil {
+		return nil, nil
+	}
+
+	var findHostData HostSearchResult
+	if err := json.Unmarshal(data, &findHostData); err != nil {
+		return nil, fmt.Errorf("error unmarshalling iptoasn data: %w", err)
+	}
+
+	// don't render if the host isn't announced by any AS
+	if !findHostData.Announced {
+		return nil, nil
+	}
+
+	tw := table.NewWriter()
+	// pad column to ensure title row fills the table
+	tw.AppendRow(table.Row{providers.PadRight("ASN", providers.Column1MinWidth), providers.DashIfEmpty(fmt.Sprintf("AS%d", findHostData.ASNumber))})
+	tw.AppendRow(table.Row{"AS Name", providers.DashIfEmpty(findHostData.ASDescription)})
+	tw.AppendRow(table.Row{"Country", providers.DashIfEmpty(findHostData.ASCountryCode)})
+	tw.AppendRow(table.Row{"Range", providers.DashIfEmpty(findHostData.FirstIP + " - " + findHostData.LastIP)})
+
+	tw.SetColumnConfigs([]table.ColumnConfig{
+		{Number: providers.DataColumnNo, AutoMerge: true, WidthMax: providers.WideColumnMaxWidth, WidthMin: providers.WideColumnMinWidth},
+		{Number: 1, AutoMerge: true},
+	})
+
+	tw.SetAutoIndex(false)
+	tw.SetTitle("IPtoASN | Host: %s", c.Host.String())
+
+	if c.UseTestData {
+		tw.SetTitle("IPtoASN | Host: 8.8.8.8")
+	}
+
+	c.Logger.Debug("iptoasn table created", "host", c.Host.String())
+
+	return &tw, nil
+}
+
+type iptoasnResp struct {
+	Announced     bool   `json:"announced"`
+	ASNumber      uint32 `json:"as_number"`
+	ASCountryCode string `json:"as_country_code"`
+	ASDescription string `json:"as_description"`
+	FirstIP       string `json:"first_ip"`
+	LastIP        string `json:"last_ip"`
+	IP            string `json:"ip"`
+}
+
+func loadResultsFile(path string) (*HostSearchResult, error) {
+	jf, err := os.Open(path) // #nosec G304 -- path is the provider's own test data file
+	if err != nil {
+		return nil, fmt.Errorf("error opening iptoasn file: %w", err)
+	}
+
+	defer jf.Close()
+
+	var res HostSearchResult
+
+	decoder := json.NewDecoder(jf)
+
+	if err = decoder.Decode(&res); err != nil {
+		return nil, fmt.Errorf("error decoding iptoasn file: %w", err)
+	}
+
+	return &res, nil
+}
+
+func loadTestData(l *slog.Logger) (*HostSearchResult, error) {
+	resultsFile, err := helpers.PrefixProjectRoot("providers/iptoasn/testdata/iptoasn_8_8_8_8_report.json")
+	if err != nil {
+		return nil, fmt.Errorf("error getting iptoasn test data file path: %w", err)
+	}
+
+	tdf, err := loadResultsFile(resultsFile)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := json.Marshal(tdf)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling iptoasn test data: %w", err)
+	}
+
+	tdf.Raw = raw
+
+	l.Debug("iptoasn match returned from test data", "host", "8.8.8.8")
+
+	return tdf, nil
+}
+
+type HostSearchResult struct {
+	Raw json.RawMessage `json:"raw,omitempty"`
+	iptoasnResp
+}

--- a/providers/iptoasn/iptoasn_network_test.go
+++ b/providers/iptoasn/iptoasn_network_test.go
@@ -1,0 +1,180 @@
+package iptoasn
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/netip"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/jonhadfield/ipscout/cache"
+	"github.com/jonhadfield/ipscout/providers"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/stretchr/testify/require"
+)
+
+// fixtureTSV mirrors the upstream ip2asn-combined format: IPv4 ranges sorted
+// ascending, including an unrouted gap, followed by IPv6 ranges.
+const fixtureTSV = "1.0.0.0\t1.0.0.255\t13335\tUS\tCLOUDFLARENET\n" +
+	"8.8.8.0\t8.8.8.255\t15169\tUS\tGOOGLE - Google LLC\n" +
+	"10.0.0.0\t10.255.255.255\t0\tNone\tNot routed\n" +
+	"2001:4860::\t2001:4860:ffff:ffff:ffff:ffff:ffff:ffff\t15169\tUS\tGOOGLE - Google LLC\n"
+
+func gzipTSV(t *testing.T) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	gz := gzip.NewWriter(&buf)
+	_, err := gz.Write([]byte(fixtureTSV))
+	require.NoError(t, err)
+	require.NoError(t, gz.Close())
+
+	return buf.Bytes()
+}
+
+// mockTransport returns a canned response for any request, so the real
+// loadProviderDataFromSource download path can run offline.
+type mockTransport struct {
+	status int
+	body   []byte
+}
+
+func (m mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: m.status,
+		Body:       io.NopCloser(bytes.NewReader(m.body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// mockHTTPClient builds a retryablehttp client whose transport serves the given
+// status and body, with retries disabled for deterministic error-path tests.
+func mockHTTPClient(status int, body []byte) *retryablehttp.Client {
+	hc := retryablehttp.NewClient()
+	hc.Logger = nil
+	hc.RetryMax = 0
+	hc.HTTPClient.Transport = mockTransport{status: status, body: body}
+
+	return hc
+}
+
+// newMockedClient builds a Client wired to a mocked HTTP client and a real temp
+// cache, with the provider enabled and UseTestData off so Initialise and
+// FindHost take the real download -> cache -> scan path.
+func newMockedClient(t *testing.T, host string, status int, body []byte) *Client {
+	t.Helper()
+
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+
+	db, err := cache.Create(lg, filepath.Join(t.TempDir(), ".config", "ipscout"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	sess := session.Session{
+		Logger:     lg,
+		Stats:      session.CreateStats(),
+		Cache:      db,
+		HTTPClient: mockHTTPClient(status, body),
+	}
+	sess.Host = netip.MustParseAddr(host)
+
+	enabled := true
+	sess.Providers.IPToASN.Enabled = &enabled
+
+	pc, err := NewProviderClient(sess)
+	require.NoError(t, err)
+
+	return pc.(*Client)
+}
+
+func TestFindHostNetworkSuccess(t *testing.T) {
+	t.Parallel()
+
+	c := newMockedClient(t, testHost, http.StatusOK, gzipTSV(t))
+
+	require.NoError(t, c.Initialise())
+
+	res, err := c.FindHost()
+	require.NoError(t, err)
+	require.NotEmpty(t, res)
+
+	var parsed HostSearchResult
+	require.NoError(t, json.Unmarshal(res, &parsed))
+	require.True(t, parsed.Announced)
+	require.Equal(t, fixtureASNumber, parsed.ASNumber)
+	require.Equal(t, fixtureCountryCode, parsed.ASCountryCode)
+	require.Equal(t, fixtureASDescription, parsed.ASDescription)
+	require.Equal(t, "8.8.8.0", parsed.FirstIP)
+	require.Equal(t, "8.8.8.255", parsed.LastIP)
+
+	require.True(t, c.Stats.FindHostUsedCache[ProviderName])
+}
+
+func TestFindHostNetworkIPv6(t *testing.T) {
+	t.Parallel()
+
+	c := newMockedClient(t, "2001:4860:4860::8888", http.StatusOK, gzipTSV(t))
+
+	require.NoError(t, c.Initialise())
+
+	res, err := c.FindHost()
+	require.NoError(t, err)
+
+	var parsed HostSearchResult
+	require.NoError(t, json.Unmarshal(res, &parsed))
+	require.True(t, parsed.Announced)
+	require.Equal(t, fixtureASNumber, parsed.ASNumber)
+}
+
+func TestFindHostNetworkNoMatch(t *testing.T) {
+	t.Parallel()
+
+	// 203.0.113.5 is beyond every IPv4 range in the fixture.
+	c := newMockedClient(t, "203.0.113.5", http.StatusOK, gzipTSV(t))
+
+	require.NoError(t, c.Initialise())
+
+	_, err := c.FindHost()
+	require.ErrorIs(t, err, providers.ErrNoMatchFound)
+}
+
+func TestFindHostNetworkNotRouted(t *testing.T) {
+	t.Parallel()
+
+	// 10.1.2.3 falls in a "Not routed" range: no ASN details to report.
+	c := newMockedClient(t, "10.1.2.3", http.StatusOK, gzipTSV(t))
+
+	require.NoError(t, c.Initialise())
+
+	_, err := c.FindHost()
+	require.ErrorIs(t, err, providers.ErrNoMatchFound)
+}
+
+func TestInitialiseDownloadError(t *testing.T) {
+	t.Parallel()
+
+	c := newMockedClient(t, testHost, http.StatusForbidden, []byte("blocked"))
+
+	err := c.Initialise()
+	require.Error(t, err)
+	require.ErrorIs(t, err, providers.ErrFailedToFetchData)
+}
+
+func TestFindHostCorruptCachedData(t *testing.T) {
+	t.Parallel()
+
+	c := newMockedClient(t, testHost, http.StatusOK, []byte("not gzip"))
+
+	require.NoError(t, c.Initialise())
+
+	_, err := c.FindHost()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "decompressing iptoasn data")
+}

--- a/providers/iptoasn/iptoasn_provider_test.go
+++ b/providers/iptoasn/iptoasn_provider_test.go
@@ -1,0 +1,243 @@
+package iptoasn
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/netip"
+	"path/filepath"
+	"testing"
+
+	"github.com/jonhadfield/ipscout/cache"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testHost                 = "8.8.8.8"
+	fixtureCountryCode       = "US"
+	fixtureASNumber          = uint32(15169)
+	fixtureASDescription     = "GOOGLE - Google LLC"
+	highThreatCountryScore   = 9.0
+	mediumThreatCountryScore = 7.0
+)
+
+// newTestProviderClient builds a ProviderClient backed by a temporary cache and
+// the UseTestData path, so the real provider logic runs without any network access.
+func newTestProviderClient(t *testing.T) *Client {
+	t.Helper()
+
+	lg := slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+
+	db, err := cache.Create(lg, filepath.Join(t.TempDir(), ".config", "ipscout"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, db.Close()) })
+
+	sess := session.Session{
+		Logger: lg,
+		Stats:  session.CreateStats(),
+		Cache:  db,
+	}
+	sess.UseTestData = true
+	sess.Host = netip.MustParseAddr(testHost)
+
+	pc, err := NewProviderClient(sess)
+	require.NoError(t, err)
+
+	return pc.(*Client)
+}
+
+func TestEnabled(t *testing.T) {
+	t.Parallel()
+
+	pc := &Client{}
+
+	// Disabled by default.
+	require.False(t, pc.Enabled())
+
+	// Enabled flag set -> enabled.
+	enabled := true
+	pc.Providers.IPToASN.Enabled = &enabled
+	require.True(t, pc.Enabled())
+
+	// Explicitly disabled.
+	disabled := false
+	pc.Providers.IPToASN.Enabled = &disabled
+	require.False(t, pc.Enabled())
+
+	// UseTestData always enables regardless of config.
+	pc.Providers.IPToASN.Enabled = nil
+	pc.UseTestData = true
+	require.True(t, pc.Enabled())
+}
+
+func TestPriority(t *testing.T) {
+	t.Parallel()
+
+	pc := &Client{}
+	require.Nil(t, pc.Priority())
+
+	priority := int32(5)
+	pc.Providers.IPToASN.OutputPriority = &priority
+	require.Equal(t, priority, *pc.Priority())
+}
+
+func TestInitialise(t *testing.T) {
+	t.Parallel()
+
+	// Missing cache -> error.
+	pc := &Client{}
+	pc.Stats = session.CreateStats()
+	pc.Logger = slog.New(slog.NewTextHandler(io.Discard, nil)) //nolint:sloglint
+	pc.Host = netip.MustParseAddr(testHost)
+	require.ErrorIs(t, pc.Initialise(), session.ErrCacheNotSet)
+
+	// Cache present -> success.
+	c := newTestProviderClient(t)
+	require.NoError(t, c.Initialise())
+}
+
+func TestGetConfig(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+	cfg := c.GetConfig()
+	require.NotNil(t, cfg)
+	require.True(t, cfg.UseTestData)
+}
+
+func TestFindHostUsesTestData(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	res, err := c.FindHost()
+	require.NoError(t, err)
+	require.NotEmpty(t, res)
+
+	var parsed HostSearchResult
+	require.NoError(t, json.Unmarshal(res, &parsed))
+	require.True(t, parsed.Announced)
+	require.Equal(t, fixtureASNumber, parsed.ASNumber)
+	require.Equal(t, fixtureCountryCode, parsed.ASCountryCode)
+	require.Equal(t, fixtureASDescription, parsed.ASDescription)
+}
+
+func TestCreateTable(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	data, err := c.FindHost()
+	require.NoError(t, err)
+
+	tw, err := c.CreateTable(data)
+	require.NoError(t, err)
+	require.NotNil(t, tw)
+
+	rendered := (*tw).Render()
+	require.NotEmpty(t, rendered)
+	require.Contains(t, rendered, "AS15169")
+	require.Contains(t, rendered, fixtureASDescription)
+}
+
+func TestCreateTableNilData(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	tw, err := c.CreateTable(nil)
+	require.NoError(t, err)
+	require.Nil(t, tw)
+}
+
+func TestCreateTableNotAnnounced(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	// An unannounced IP has no ASN details -> nothing to render.
+	tw, err := c.CreateTable([]byte(`{"announced":false,"ip":"192.0.2.1"}`))
+	require.NoError(t, err)
+	require.Nil(t, tw)
+}
+
+func TestExtractThreatIndicators(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	data, err := c.FindHost()
+	require.NoError(t, err)
+
+	indicators, err := c.ExtractThreatIndicators(data)
+	require.NoError(t, err)
+	require.Equal(t, ProviderName, indicators.Provider)
+	require.Equal(t, fixtureCountryCode, indicators.Indicators["CountryCode"])
+}
+
+func TestRateHostDataHighThreatCountry(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	data, err := c.FindHost()
+	require.NoError(t, err)
+
+	// US is the country in the fixture; flag it as high threat.
+	ratingConfigJSON := `{
+		"global": {
+			"highThreatCountryCodes": ["US"]
+		}
+	}`
+
+	result, err := c.RateHostData(data, []byte(ratingConfigJSON))
+	require.NoError(t, err)
+	require.True(t, result.Detected)
+	require.Equal(t, highThreatCountryScore, result.Score)
+	require.Contains(t, result.Reasons, "High Threat Country: US")
+}
+
+func TestRateHostDataMediumThreatCountry(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	data, err := c.FindHost()
+	require.NoError(t, err)
+
+	ratingConfigJSON := `{
+		"global": {
+			"mediumThreatCountryCodes": ["US"]
+		}
+	}`
+
+	result, err := c.RateHostData(data, []byte(ratingConfigJSON))
+	require.NoError(t, err)
+	require.True(t, result.Detected)
+	require.Equal(t, mediumThreatCountryScore, result.Score)
+	require.Contains(t, result.Reasons, "Medium Threat Country: US")
+}
+
+func TestRateHostDataNoThreat(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	data, err := c.FindHost()
+	require.NoError(t, err)
+
+	result, err := c.RateHostData(data, []byte(`{"global":{}}`))
+	require.NoError(t, err)
+	require.False(t, result.Detected)
+	require.Zero(t, result.Score)
+}
+
+func TestRateHostDataInvalidConfig(t *testing.T) {
+	t.Parallel()
+
+	c := newTestProviderClient(t)
+
+	_, err := c.RateHostData([]byte(`{}`), []byte("not json"))
+	require.Error(t, err)
+}

--- a/providers/iptoasn/testdata/iptoasn_8_8_8_8_report.json
+++ b/providers/iptoasn/testdata/iptoasn_8_8_8_8_report.json
@@ -1,0 +1,9 @@
+{
+  "announced": true,
+  "as_country_code": "US",
+  "as_description": "GOOGLE - Google LLC",
+  "as_number": 15169,
+  "first_ip": "8.8.8.0",
+  "ip": "8.8.8.8",
+  "last_ip": "8.8.8.255"
+}

--- a/providers/shodan/shodan.go
+++ b/providers/shodan/shodan.go
@@ -362,7 +362,7 @@ func fetchData(c session.Session) (*HostSearchResult, error) {
 }
 
 func (c *ProviderClient) Initialise() error {
-	c.Logger.Info("initialising cache", "provider", ProviderName, "host", c.Host.String(), "cache", c.Cache == nil)
+	c.Logger.Debug("initialising cache", "provider", ProviderName, "host", c.Host.String(), "cache", c.Cache == nil)
 
 	if c.Cache == nil {
 		return session.ErrCacheNotSet

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,6 +1,11 @@
 package registry
 
 import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
 	"github.com/jonhadfield/ipscout/providers"
 	"github.com/jonhadfield/ipscout/providers/abuseipdb"
 	"github.com/jonhadfield/ipscout/providers/alibaba"
@@ -44,7 +49,12 @@ import (
 	"github.com/jonhadfield/ipscout/providers/zscaler"
 	"github.com/jonhadfield/ipscout/session"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
+
+// yamlIndent is the indentation used when rewriting the config file, matching
+// the shipped default config.
+const yamlIndent = 2
 
 // Entry describes a provider and how to instantiate it.
 type Entry struct {
@@ -61,6 +71,107 @@ type Entry struct {
 	DefaultEnabled bool
 }
 
+// EnsureDefaultProvidersInConfig adds an enabled=true entry to the config file
+// at configPath for every no-config provider missing from its providers
+// section, so existing users see newly added providers in their config as
+// enabled. Comments and ordering of existing entries are preserved. It returns
+// true if the file was updated.
+func EnsureDefaultProvidersInConfig(configPath string) (bool, error) {
+	info, err := os.Stat(configPath)
+	if err != nil {
+		return false, fmt.Errorf("failed to stat config file: %w", err)
+	}
+
+	data, err := os.ReadFile(configPath) // #nosec G304 -- path is the app's own config file
+	if err != nil {
+		return false, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	var doc yaml.Node
+	if err = yaml.Unmarshal(data, &doc); err != nil {
+		return false, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 || doc.Content[0].Kind != yaml.MappingNode {
+		return false, nil
+	}
+
+	root := doc.Content[0]
+
+	var providersNode *yaml.Node
+
+	for i := 0; i < len(root.Content)-1; i += 2 {
+		if root.Content[i].Value == "providers" {
+			providersNode = root.Content[i+1]
+
+			break
+		}
+	}
+
+	if providersNode == nil {
+		providersNode = &yaml.Node{Kind: yaml.MappingNode}
+		root.Content = append(root.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: "providers"},
+			providersNode)
+	}
+
+	// an empty providers section parses as a null scalar
+	if providersNode.Kind != yaml.MappingNode {
+		providersNode.Kind = yaml.MappingNode
+		providersNode.Tag = ""
+		providersNode.Value = ""
+		providersNode.Content = nil
+	}
+
+	existing := make(map[string]bool)
+	for i := 0; i < len(providersNode.Content)-1; i += 2 {
+		existing[strings.ToLower(providersNode.Content[i].Value)] = true
+	}
+
+	var changed bool
+
+	for _, e := range All() {
+		// config keys are lowercase by convention; some ProviderName
+		// constants (e.g. M247) are not
+		name := strings.ToLower(e.Name)
+		if !e.DefaultEnabled || existing[name] {
+			continue
+		}
+
+		providersNode.Content = append(providersNode.Content,
+			&yaml.Node{Kind: yaml.ScalarNode, Value: name},
+			&yaml.Node{Kind: yaml.MappingNode, Content: []*yaml.Node{
+				{Kind: yaml.ScalarNode, Value: "enabled"},
+				{Kind: yaml.ScalarNode, Value: "true"},
+			}})
+
+		changed = true
+	}
+
+	if !changed {
+		return false, nil
+	}
+
+	var buf bytes.Buffer
+
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(yamlIndent)
+
+	if err = enc.Encode(&doc); err != nil {
+		return false, fmt.Errorf("failed to encode config file: %w", err)
+	}
+
+	if err = enc.Close(); err != nil {
+		return false, fmt.Errorf("failed to encode config file: %w", err)
+	}
+
+	if err = os.WriteFile(configPath, buf.Bytes(), info.Mode().Perm()); err != nil {
+		return false, fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return true, nil
+}
+
 // SetEnabledDefaults registers an enabled=true default for every provider that
 // requires no configuration, so providers added after a user's config file was
 // written are still enabled rather than silently skipped. Explicit config
@@ -68,7 +179,7 @@ type Entry struct {
 func SetEnabledDefaults(v *viper.Viper) {
 	for _, e := range All() {
 		if e.DefaultEnabled {
-			v.SetDefault("providers."+e.Name+".enabled", true)
+			v.SetDefault("providers."+strings.ToLower(e.Name)+".enabled", true)
 		}
 	}
 }
@@ -94,7 +205,7 @@ func All() []Entry {
 		{Name: ipapi.ProviderName, DisplayName: "IPAPI", Enabled: func(s session.Session) *bool { return s.Providers.IPAPI.Enabled }, APIKey: noKey, NewClient: ipapi.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: ipqs.ProviderName, DisplayName: "IPQualityScore", Enabled: func(s session.Session) *bool { return s.Providers.IPQS.Enabled }, APIKey: func(s session.Session) string { return s.Providers.IPQS.APIKey }, NewClient: ipqs.NewProviderClient, SupportsRating: true},
 		{Name: ipurl.ProviderName, DisplayName: "IPURL", Enabled: func(s session.Session) *bool { return s.Providers.IPURL.Enabled }, APIKey: noKey, NewClient: ipurl.NewProviderClient, SupportsRating: true},
-		{Name: icloudpr.ProviderName, DisplayName: "iCloud Private Relay", Enabled: func(s session.Session) *bool { return s.Providers.ICloudPR.Enabled }, APIKey: noKey, NewClient: icloudpr.NewProviderClient, SupportsRating: true},
+		{Name: icloudpr.ProviderName, DisplayName: "iCloud Private Relay", Enabled: func(s session.Session) *bool { return s.Providers.ICloudPR.Enabled }, APIKey: noKey, NewClient: icloudpr.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: linode.ProviderName, DisplayName: "Linode", Enabled: func(s session.Session) *bool { return s.Providers.Linode.Enabled }, APIKey: noKey, NewClient: linode.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: m247.ProviderName, DisplayName: "M247", Enabled: func(s session.Session) *bool { return s.Providers.M247.Enabled }, APIKey: noKey, NewClient: m247.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: openai.ProviderName, DisplayName: "OpenAI", Enabled: func(s session.Session) *bool { return s.Providers.OpenAI.Enabled }, APIKey: noKey, NewClient: openai.NewProviderClient, SupportsRating: true, DefaultEnabled: true},

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -43,6 +43,7 @@ import (
 	"github.com/jonhadfield/ipscout/providers/vultr"
 	"github.com/jonhadfield/ipscout/providers/zscaler"
 	"github.com/jonhadfield/ipscout/session"
+	"github.com/spf13/viper"
 )
 
 // Entry describes a provider and how to instantiate it.
@@ -54,6 +55,22 @@ type Entry struct {
 	APIKey         func(sess session.Session) string
 	NewClient      func(sess session.Session) (providers.ProviderClient, error)
 	SupportsRating bool
+	// DefaultEnabled marks providers that require no configuration (no API
+	// key, paths, URLs or resource IDs) and are therefore enabled by default
+	// when absent from the user's config file.
+	DefaultEnabled bool
+}
+
+// SetEnabledDefaults registers an enabled=true default for every provider that
+// requires no configuration, so providers added after a user's config file was
+// written are still enabled rather than silently skipped. Explicit config
+// values always take precedence over these defaults.
+func SetEnabledDefaults(v *viper.Viper) {
+	for _, e := range All() {
+		if e.DefaultEnabled {
+			v.SetDefault("providers."+e.Name+".enabled", true)
+		}
+	}
 }
 
 // All returns the full list of known provider registrations.
@@ -61,45 +78,45 @@ type Entry struct {
 func All() []Entry {
 	return []Entry{
 		{Name: abuseipdb.ProviderName, DisplayName: "AbuseIPDB", Enabled: func(s session.Session) *bool { return s.Providers.AbuseIPDB.Enabled }, APIKey: func(s session.Session) string { return s.Providers.AbuseIPDB.APIKey }, NewClient: abuseipdb.NewClient, SupportsRating: true},
-		{Name: alibaba.ProviderName, DisplayName: "Alibaba", Enabled: func(s session.Session) *bool { return s.Providers.Alibaba.Enabled }, APIKey: noKey, NewClient: alibaba.NewProviderClient, SupportsRating: true},
+		{Name: alibaba.ProviderName, DisplayName: "Alibaba", Enabled: func(s session.Session) *bool { return s.Providers.Alibaba.Enabled }, APIKey: noKey, NewClient: alibaba.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: annotated.ProviderName, DisplayName: "Annotated", Enabled: func(s session.Session) *bool { return s.Providers.Annotated.Enabled }, APIKey: noKey, NewClient: annotated.NewProviderClient, SupportsRating: true},
-		{Name: aws.ProviderName, DisplayName: "AWS", Enabled: func(s session.Session) *bool { return s.Providers.AWS.Enabled }, APIKey: noKey, NewClient: aws.NewProviderClient, SupportsRating: true},
-		{Name: azure.ProviderName, DisplayName: "Azure", Enabled: func(s session.Session) *bool { return s.Providers.Azure.Enabled }, APIKey: noKey, NewClient: azure.NewProviderClient, SupportsRating: true},
+		{Name: aws.ProviderName, DisplayName: "AWS", Enabled: func(s session.Session) *bool { return s.Providers.AWS.Enabled }, APIKey: noKey, NewClient: aws.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: azure.ProviderName, DisplayName: "Azure", Enabled: func(s session.Session) *bool { return s.Providers.Azure.Enabled }, APIKey: noKey, NewClient: azure.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: azurewaf.ProviderName, DisplayName: "Azure WAF", Enabled: func(s session.Session) *bool { return s.Providers.AzureWAF.Enabled }, APIKey: noKey, NewClient: azurewaf.NewProviderClient, SupportsRating: false},
-		{Name: bingbot.ProviderName, DisplayName: "Bingbot", Enabled: func(s session.Session) *bool { return s.Providers.Bingbot.Enabled }, APIKey: noKey, NewClient: bingbot.NewProviderClient, SupportsRating: true},
+		{Name: bingbot.ProviderName, DisplayName: "Bingbot", Enabled: func(s session.Session) *bool { return s.Providers.Bingbot.Enabled }, APIKey: noKey, NewClient: bingbot.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: criminalip.ProviderName, DisplayName: "CriminalIP", Enabled: func(s session.Session) *bool { return s.Providers.CriminalIP.Enabled }, APIKey: func(s session.Session) string { return s.Providers.CriminalIP.APIKey }, NewClient: criminalip.NewProviderClient, SupportsRating: true},
-		{Name: digitalocean.ProviderName, DisplayName: "DigitalOcean", Enabled: func(s session.Session) *bool { return s.Providers.DigitalOcean.Enabled }, APIKey: noKey, NewClient: digitalocean.NewProviderClient, SupportsRating: true},
-		{Name: gcp.ProviderName, DisplayName: "GCP", Enabled: func(s session.Session) *bool { return s.Providers.GCP.Enabled }, APIKey: noKey, NewClient: gcp.NewProviderClient, SupportsRating: true},
-		{Name: google.ProviderName, DisplayName: "Google", Enabled: func(s session.Session) *bool { return s.Providers.Google.Enabled }, APIKey: noKey, NewClient: google.NewProviderClient, SupportsRating: true},
-		{Name: googlebot.ProviderName, DisplayName: "Googlebot", Enabled: func(s session.Session) *bool { return s.Providers.Googlebot.Enabled }, APIKey: noKey, NewClient: googlebot.NewProviderClient, SupportsRating: true},
-		{Name: googlesc.ProviderName, DisplayName: "Google Special-case Crawlers", Enabled: func(s session.Session) *bool { return s.Providers.GoogleSC.Enabled }, APIKey: noKey, NewClient: googlesc.NewProviderClient, SupportsRating: true},
-		{Name: hetzner.ProviderName, DisplayName: "Hetzner", Enabled: func(s session.Session) *bool { return s.Providers.Hetzner.Enabled }, APIKey: noKey, NewClient: hetzner.NewProviderClient, SupportsRating: true},
-		{Name: ipapi.ProviderName, DisplayName: "IPAPI", Enabled: func(s session.Session) *bool { return s.Providers.IPAPI.Enabled }, APIKey: noKey, NewClient: ipapi.NewProviderClient, SupportsRating: true},
+		{Name: digitalocean.ProviderName, DisplayName: "DigitalOcean", Enabled: func(s session.Session) *bool { return s.Providers.DigitalOcean.Enabled }, APIKey: noKey, NewClient: digitalocean.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: gcp.ProviderName, DisplayName: "GCP", Enabled: func(s session.Session) *bool { return s.Providers.GCP.Enabled }, APIKey: noKey, NewClient: gcp.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: google.ProviderName, DisplayName: "Google", Enabled: func(s session.Session) *bool { return s.Providers.Google.Enabled }, APIKey: noKey, NewClient: google.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: googlebot.ProviderName, DisplayName: "Googlebot", Enabled: func(s session.Session) *bool { return s.Providers.Googlebot.Enabled }, APIKey: noKey, NewClient: googlebot.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: googlesc.ProviderName, DisplayName: "Google Special-case Crawlers", Enabled: func(s session.Session) *bool { return s.Providers.GoogleSC.Enabled }, APIKey: noKey, NewClient: googlesc.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: hetzner.ProviderName, DisplayName: "Hetzner", Enabled: func(s session.Session) *bool { return s.Providers.Hetzner.Enabled }, APIKey: noKey, NewClient: hetzner.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: ipapi.ProviderName, DisplayName: "IPAPI", Enabled: func(s session.Session) *bool { return s.Providers.IPAPI.Enabled }, APIKey: noKey, NewClient: ipapi.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: ipqs.ProviderName, DisplayName: "IPQualityScore", Enabled: func(s session.Session) *bool { return s.Providers.IPQS.Enabled }, APIKey: func(s session.Session) string { return s.Providers.IPQS.APIKey }, NewClient: ipqs.NewProviderClient, SupportsRating: true},
 		{Name: ipurl.ProviderName, DisplayName: "IPURL", Enabled: func(s session.Session) *bool { return s.Providers.IPURL.Enabled }, APIKey: noKey, NewClient: ipurl.NewProviderClient, SupportsRating: true},
 		{Name: icloudpr.ProviderName, DisplayName: "iCloud Private Relay", Enabled: func(s session.Session) *bool { return s.Providers.ICloudPR.Enabled }, APIKey: noKey, NewClient: icloudpr.NewProviderClient, SupportsRating: true},
-		{Name: linode.ProviderName, DisplayName: "Linode", Enabled: func(s session.Session) *bool { return s.Providers.Linode.Enabled }, APIKey: noKey, NewClient: linode.NewProviderClient, SupportsRating: true},
-		{Name: m247.ProviderName, DisplayName: "M247", Enabled: func(s session.Session) *bool { return s.Providers.M247.Enabled }, APIKey: noKey, NewClient: m247.NewProviderClient, SupportsRating: true},
-		{Name: openai.ProviderName, DisplayName: "OpenAI", Enabled: func(s session.Session) *bool { return s.Providers.OpenAI.Enabled }, APIKey: noKey, NewClient: openai.NewProviderClient, SupportsRating: true},
-		{Name: ovh.ProviderName, DisplayName: "OVH", Enabled: func(s session.Session) *bool { return s.Providers.OVH.Enabled }, APIKey: noKey, NewClient: ovh.NewProviderClient, SupportsRating: true},
-		{Name: scaleway.ProviderName, DisplayName: "Scaleway", Enabled: func(s session.Session) *bool { return s.Providers.Scaleway.Enabled }, APIKey: noKey, NewClient: scaleway.NewProviderClient, SupportsRating: true},
-		{Name: ptr.ProviderName, DisplayName: "PTR", Enabled: func(s session.Session) *bool { return s.Providers.PTR.Enabled }, APIKey: noKey, NewClient: ptr.NewProviderClient, SupportsRating: false},
+		{Name: linode.ProviderName, DisplayName: "Linode", Enabled: func(s session.Session) *bool { return s.Providers.Linode.Enabled }, APIKey: noKey, NewClient: linode.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: m247.ProviderName, DisplayName: "M247", Enabled: func(s session.Session) *bool { return s.Providers.M247.Enabled }, APIKey: noKey, NewClient: m247.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: openai.ProviderName, DisplayName: "OpenAI", Enabled: func(s session.Session) *bool { return s.Providers.OpenAI.Enabled }, APIKey: noKey, NewClient: openai.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: ovh.ProviderName, DisplayName: "OVH", Enabled: func(s session.Session) *bool { return s.Providers.OVH.Enabled }, APIKey: noKey, NewClient: ovh.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: scaleway.ProviderName, DisplayName: "Scaleway", Enabled: func(s session.Session) *bool { return s.Providers.Scaleway.Enabled }, APIKey: noKey, NewClient: scaleway.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: ptr.ProviderName, DisplayName: "PTR", Enabled: func(s session.Session) *bool { return s.Providers.PTR.Enabled }, APIKey: noKey, NewClient: ptr.NewProviderClient, SupportsRating: false, DefaultEnabled: true},
 		{Name: shodan.ProviderName, DisplayName: "Shodan", Enabled: func(s session.Session) *bool { return s.Providers.Shodan.Enabled }, APIKey: func(s session.Session) string { return s.Providers.Shodan.APIKey }, NewClient: shodan.NewProviderClient, SupportsRating: true},
 		{Name: virustotal.ProviderName, DisplayName: "VirusTotal", Enabled: func(s session.Session) *bool { return s.Providers.VirusTotal.Enabled }, APIKey: func(s session.Session) string { return s.Providers.VirusTotal.APIKey }, NewClient: virustotal.NewProviderClient, SupportsRating: true},
-		{Name: vultr.ProviderName, DisplayName: "Vultr", Enabled: func(s session.Session) *bool { return s.Providers.Vultr.Enabled }, APIKey: noKey, NewClient: vultr.NewProviderClient, SupportsRating: true},
-		{Name: zscaler.ProviderName, DisplayName: "Zscaler", Enabled: func(s session.Session) *bool { return s.Providers.Zscaler.Enabled }, APIKey: noKey, NewClient: zscaler.NewProviderClient, SupportsRating: true},
-		{Name: atlassian.ProviderName, DisplayName: "Atlassian", Enabled: func(s session.Session) *bool { return s.Providers.Atlassian.Enabled }, APIKey: noKey, NewClient: atlassian.NewProviderClient, SupportsRating: true},
-		{Name: bunny.ProviderName, DisplayName: "Bunny CDN", Enabled: func(s session.Session) *bool { return s.Providers.Bunny.Enabled }, APIKey: noKey, NewClient: bunny.NewProviderClient, SupportsRating: true},
-		{Name: cdn77.ProviderName, DisplayName: "CDN77", Enabled: func(s session.Session) *bool { return s.Providers.CDN77.Enabled }, APIKey: noKey, NewClient: cdn77.NewProviderClient, SupportsRating: true},
-		{Name: contabo.ProviderName, DisplayName: "Contabo", Enabled: func(s session.Session) *bool { return s.Providers.Contabo.Enabled }, APIKey: noKey, NewClient: contabo.NewProviderClient, SupportsRating: true},
-		{Name: datadog.ProviderName, DisplayName: "Datadog", Enabled: func(s session.Session) *bool { return s.Providers.Datadog.Enabled }, APIKey: noKey, NewClient: datadog.NewProviderClient, SupportsRating: true},
-		{Name: flyio.ProviderName, DisplayName: "Fly.io", Enabled: func(s session.Session) *bool { return s.Providers.Flyio.Enabled }, APIKey: noKey, NewClient: flyio.NewProviderClient, SupportsRating: true},
-		{Name: ibmcloud.ProviderName, DisplayName: "IBM Cloud", Enabled: func(s session.Session) *bool { return s.Providers.IBMCloud.Enabled }, APIKey: noKey, NewClient: ibmcloud.NewProviderClient, SupportsRating: true},
-		{Name: imperva.ProviderName, DisplayName: "Imperva", Enabled: func(s session.Session) *bool { return s.Providers.Imperva.Enabled }, APIKey: noKey, NewClient: imperva.NewProviderClient, SupportsRating: true},
-		{Name: leaseweb.ProviderName, DisplayName: "Leaseweb", Enabled: func(s session.Session) *bool { return s.Providers.Leaseweb.Enabled }, APIKey: noKey, NewClient: leaseweb.NewProviderClient, SupportsRating: true},
-		{Name: render.ProviderName, DisplayName: "Render", Enabled: func(s session.Session) *bool { return s.Providers.Render.Enabled }, APIKey: noKey, NewClient: render.NewProviderClient, SupportsRating: true},
-		{Name: stripe.ProviderName, DisplayName: "Stripe", Enabled: func(s session.Session) *bool { return s.Providers.Stripe.Enabled }, APIKey: noKey, NewClient: stripe.NewProviderClient, SupportsRating: true},
-		{Name: tencent.ProviderName, DisplayName: "Tencent Cloud", Enabled: func(s session.Session) *bool { return s.Providers.Tencent.Enabled }, APIKey: noKey, NewClient: tencent.NewProviderClient, SupportsRating: true},
+		{Name: vultr.ProviderName, DisplayName: "Vultr", Enabled: func(s session.Session) *bool { return s.Providers.Vultr.Enabled }, APIKey: noKey, NewClient: vultr.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: zscaler.ProviderName, DisplayName: "Zscaler", Enabled: func(s session.Session) *bool { return s.Providers.Zscaler.Enabled }, APIKey: noKey, NewClient: zscaler.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: atlassian.ProviderName, DisplayName: "Atlassian", Enabled: func(s session.Session) *bool { return s.Providers.Atlassian.Enabled }, APIKey: noKey, NewClient: atlassian.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: bunny.ProviderName, DisplayName: "Bunny CDN", Enabled: func(s session.Session) *bool { return s.Providers.Bunny.Enabled }, APIKey: noKey, NewClient: bunny.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: cdn77.ProviderName, DisplayName: "CDN77", Enabled: func(s session.Session) *bool { return s.Providers.CDN77.Enabled }, APIKey: noKey, NewClient: cdn77.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: contabo.ProviderName, DisplayName: "Contabo", Enabled: func(s session.Session) *bool { return s.Providers.Contabo.Enabled }, APIKey: noKey, NewClient: contabo.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: datadog.ProviderName, DisplayName: "Datadog", Enabled: func(s session.Session) *bool { return s.Providers.Datadog.Enabled }, APIKey: noKey, NewClient: datadog.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: flyio.ProviderName, DisplayName: "Fly.io", Enabled: func(s session.Session) *bool { return s.Providers.Flyio.Enabled }, APIKey: noKey, NewClient: flyio.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: ibmcloud.ProviderName, DisplayName: "IBM Cloud", Enabled: func(s session.Session) *bool { return s.Providers.IBMCloud.Enabled }, APIKey: noKey, NewClient: ibmcloud.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: imperva.ProviderName, DisplayName: "Imperva", Enabled: func(s session.Session) *bool { return s.Providers.Imperva.Enabled }, APIKey: noKey, NewClient: imperva.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: leaseweb.ProviderName, DisplayName: "Leaseweb", Enabled: func(s session.Session) *bool { return s.Providers.Leaseweb.Enabled }, APIKey: noKey, NewClient: leaseweb.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: render.ProviderName, DisplayName: "Render", Enabled: func(s session.Session) *bool { return s.Providers.Render.Enabled }, APIKey: noKey, NewClient: render.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: stripe.ProviderName, DisplayName: "Stripe", Enabled: func(s session.Session) *bool { return s.Providers.Stripe.Enabled }, APIKey: noKey, NewClient: stripe.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
+		{Name: tencent.ProviderName, DisplayName: "Tencent Cloud", Enabled: func(s session.Session) *bool { return s.Providers.Tencent.Enabled }, APIKey: noKey, NewClient: tencent.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 	}
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jonhadfield/ipscout/providers/imperva"
 	"github.com/jonhadfield/ipscout/providers/ipapi"
 	"github.com/jonhadfield/ipscout/providers/ipqs"
+	"github.com/jonhadfield/ipscout/providers/iptoasn"
 	"github.com/jonhadfield/ipscout/providers/ipurl"
 	"github.com/jonhadfield/ipscout/providers/leaseweb"
 	"github.com/jonhadfield/ipscout/providers/linode"
@@ -204,6 +205,7 @@ func All() []Entry {
 		{Name: hetzner.ProviderName, DisplayName: "Hetzner", Enabled: func(s session.Session) *bool { return s.Providers.Hetzner.Enabled }, APIKey: noKey, NewClient: hetzner.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: ipapi.ProviderName, DisplayName: "IPAPI", Enabled: func(s session.Session) *bool { return s.Providers.IPAPI.Enabled }, APIKey: noKey, NewClient: ipapi.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: ipqs.ProviderName, DisplayName: "IPQualityScore", Enabled: func(s session.Session) *bool { return s.Providers.IPQS.Enabled }, APIKey: func(s session.Session) string { return s.Providers.IPQS.APIKey }, NewClient: ipqs.NewProviderClient, SupportsRating: true},
+		{Name: iptoasn.ProviderName, DisplayName: "IPtoASN", Enabled: func(s session.Session) *bool { return s.Providers.IPToASN.Enabled }, APIKey: noKey, NewClient: iptoasn.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: ipurl.ProviderName, DisplayName: "IPURL", Enabled: func(s session.Session) *bool { return s.Providers.IPURL.Enabled }, APIKey: noKey, NewClient: ipurl.NewProviderClient, SupportsRating: true},
 		{Name: icloudpr.ProviderName, DisplayName: "iCloud Private Relay", Enabled: func(s session.Session) *bool { return s.Providers.ICloudPR.Enabled }, APIKey: noKey, NewClient: icloudpr.NewProviderClient, SupportsRating: true, DefaultEnabled: true},
 		{Name: linode.ProviderName, DisplayName: "Linode", Enabled: func(s session.Session) *bool { return s.Providers.Linode.Enabled }, APIKey: noKey, NewClient: linode.NewProviderClient, SupportsRating: true, DefaultEnabled: true},

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -189,10 +189,10 @@ func TestNoKeyHelper(t *testing.T) {
 
 // configProviders reads the providers section of a config file into a map of
 // provider name to its settings.
-func configProviders(t *testing.T, path string) map[string]map[string]any {
+func configProviders(t *testing.T) map[string]map[string]any {
 	t.Helper()
 
-	data, err := os.ReadFile(path) // #nosec G304 -- test reads its own temp file
+	data, err := os.ReadFile("config.yaml")
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
 	}
@@ -209,7 +209,9 @@ func configProviders(t *testing.T, path string) map[string]map[string]any {
 }
 
 func TestEnsureDefaultProvidersInConfigAddsMissing(t *testing.T) {
-	t.Parallel()
+	// t.Chdir is incompatible with t.Parallel; the literal config path keeps
+	// the Codacy fileread rule satisfied
+	t.Chdir(t.TempDir())
 
 	// an aged config: a comment, one no-config provider explicitly disabled,
 	// one enabled, and none of the newer providers
@@ -227,12 +229,11 @@ providers:
     enabled: true
 `
 
-	path := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+	if err := os.WriteFile("config.yaml", []byte(content), 0o600); err != nil {
 		t.Fatalf("failed to write config: %v", err)
 	}
 
-	changed, err := EnsureDefaultProvidersInConfig(path)
+	changed, err := EnsureDefaultProvidersInConfig("config.yaml")
 	if err != nil {
 		t.Fatalf("EnsureDefaultProvidersInConfig() error: %v", err)
 	}
@@ -241,7 +242,7 @@ providers:
 		t.Fatal("EnsureDefaultProvidersInConfig() = false, want true")
 	}
 
-	provs := configProviders(t, path)
+	provs := configProviders(t)
 
 	for _, e := range All() {
 		if !e.DefaultEnabled || e.Name == aws.ProviderName || e.Name == "azure" {
@@ -271,7 +272,7 @@ providers:
 	}
 
 	// comments must survive the rewrite
-	raw, err := os.ReadFile(path) // #nosec G304 -- test reads its own temp file
+	raw, err := os.ReadFile("config.yaml")
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
 	}
@@ -281,7 +282,7 @@ providers:
 	}
 
 	// a second run must be a no-op
-	changed, err = EnsureDefaultProvidersInConfig(path)
+	changed, err = EnsureDefaultProvidersInConfig("config.yaml")
 	if err != nil {
 		t.Fatalf("EnsureDefaultProvidersInConfig() second run error: %v", err)
 	}
@@ -295,14 +296,15 @@ providers:
 // shipped default config already lists every no-config provider, so a fresh
 // install's config is never rewritten on first run.
 func TestEnsureDefaultProvidersInConfigDefaultConfigComplete(t *testing.T) {
-	t.Parallel()
+	// t.Chdir is incompatible with t.Parallel; the literal config path keeps
+	// the Codacy fileread rule satisfied
+	t.Chdir(t.TempDir())
 
-	path := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(path, []byte(session.DefaultConfig), 0o600); err != nil {
+	if err := os.WriteFile("config.yaml", []byte(session.DefaultConfig), 0o600); err != nil {
 		t.Fatalf("failed to write config: %v", err)
 	}
 
-	changed, err := EnsureDefaultProvidersInConfig(path)
+	changed, err := EnsureDefaultProvidersInConfig("config.yaml")
 	if err != nil {
 		t.Fatalf("EnsureDefaultProvidersInConfig() error: %v", err)
 	}
@@ -311,7 +313,7 @@ func TestEnsureDefaultProvidersInConfigDefaultConfigComplete(t *testing.T) {
 		t.Error("default config is missing no-config providers; update session/config.yaml")
 	}
 
-	raw, err := os.ReadFile(path) // #nosec G304 -- test reads its own temp file
+	raw, err := os.ReadFile("config.yaml")
 	if err != nil {
 		t.Fatalf("failed to read config: %v", err)
 	}
@@ -322,14 +324,15 @@ func TestEnsureDefaultProvidersInConfigDefaultConfigComplete(t *testing.T) {
 }
 
 func TestEnsureDefaultProvidersInConfigEmptyProviders(t *testing.T) {
-	t.Parallel()
+	// t.Chdir is incompatible with t.Parallel; the literal config path keeps
+	// the Codacy fileread rule satisfied
+	t.Chdir(t.TempDir())
 
-	path := filepath.Join(t.TempDir(), "config.yaml")
-	if err := os.WriteFile(path, []byte("providers:\n"), 0o600); err != nil {
+	if err := os.WriteFile("config.yaml", []byte("providers:\n"), 0o600); err != nil {
 		t.Fatalf("failed to write config: %v", err)
 	}
 
-	changed, err := EnsureDefaultProvidersInConfig(path)
+	changed, err := EnsureDefaultProvidersInConfig("config.yaml")
 	if err != nil {
 		t.Fatalf("EnsureDefaultProvidersInConfig() error: %v", err)
 	}
@@ -338,7 +341,7 @@ func TestEnsureDefaultProvidersInConfigEmptyProviders(t *testing.T) {
 		t.Fatal("EnsureDefaultProvidersInConfig() = false, want true")
 	}
 
-	provs := configProviders(t, path)
+	provs := configProviders(t)
 
 	for _, e := range All() {
 		if !e.DefaultEnabled {

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,9 +1,14 @@
 package registry
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/jonhadfield/ipscout/providers/aws"
 	"github.com/jonhadfield/ipscout/session"
+	"gopkg.in/yaml.v3"
 )
 
 // expectedProviderCount is the number of provider entries currently registered
@@ -179,5 +184,177 @@ func TestNoKeyHelper(t *testing.T) {
 
 	if got := noKey(sess); got != "" {
 		t.Errorf("noKey() = %q, want empty string", got)
+	}
+}
+
+// configProviders reads the providers section of a config file into a map of
+// provider name to its settings.
+func configProviders(t *testing.T, path string) map[string]map[string]any {
+	t.Helper()
+
+	data, err := os.ReadFile(path) // #nosec G304 -- test reads its own temp file
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	var conf struct {
+		Providers map[string]map[string]any `yaml:"providers"`
+	}
+
+	if err := yaml.Unmarshal(data, &conf); err != nil {
+		t.Fatalf("failed to parse config: %v", err)
+	}
+
+	return conf.Providers
+}
+
+func TestEnsureDefaultProvidersInConfigAddsMissing(t *testing.T) {
+	t.Parallel()
+
+	// an aged config: a comment, one no-config provider explicitly disabled,
+	// one enabled, and none of the newer providers
+	content := `---
+global:
+  max_age: 90d
+
+providers:
+  # aws disabled on purpose
+  aws:
+    enabled: false
+  azure:
+    enabled: true
+  shodan:
+    enabled: true
+`
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	changed, err := EnsureDefaultProvidersInConfig(path)
+	if err != nil {
+		t.Fatalf("EnsureDefaultProvidersInConfig() error: %v", err)
+	}
+
+	if !changed {
+		t.Fatal("EnsureDefaultProvidersInConfig() = false, want true")
+	}
+
+	provs := configProviders(t, path)
+
+	for _, e := range All() {
+		if !e.DefaultEnabled || e.Name == aws.ProviderName || e.Name == "azure" {
+			continue
+		}
+
+		p, ok := provs[strings.ToLower(e.Name)]
+		if !ok {
+			t.Errorf("provider %q not added to config", e.Name)
+
+			continue
+		}
+
+		if enabled, _ := p["enabled"].(bool); !enabled {
+			t.Errorf("provider %q added with enabled=%v, want true", e.Name, p["enabled"])
+		}
+	}
+
+	// explicit user setting must be preserved
+	if enabled, _ := provs[aws.ProviderName]["enabled"].(bool); enabled {
+		t.Error("aws enabled=false was not preserved")
+	}
+
+	// keyed providers must not be added beyond those already present
+	if _, ok := provs["abuseipdb"]; ok {
+		t.Error("keyed provider abuseipdb should not be added")
+	}
+
+	// comments must survive the rewrite
+	raw, err := os.ReadFile(path) // #nosec G304 -- test reads its own temp file
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if !strings.Contains(string(raw), "# aws disabled on purpose") {
+		t.Error("comment was not preserved in rewritten config")
+	}
+
+	// a second run must be a no-op
+	changed, err = EnsureDefaultProvidersInConfig(path)
+	if err != nil {
+		t.Fatalf("EnsureDefaultProvidersInConfig() second run error: %v", err)
+	}
+
+	if changed {
+		t.Error("EnsureDefaultProvidersInConfig() second run = true, want false")
+	}
+}
+
+// TestEnsureDefaultProvidersInConfigDefaultConfigComplete guards that the
+// shipped default config already lists every no-config provider, so a fresh
+// install's config is never rewritten on first run.
+func TestEnsureDefaultProvidersInConfigDefaultConfigComplete(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(session.DefaultConfig), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	changed, err := EnsureDefaultProvidersInConfig(path)
+	if err != nil {
+		t.Fatalf("EnsureDefaultProvidersInConfig() error: %v", err)
+	}
+
+	if changed {
+		t.Error("default config is missing no-config providers; update session/config.yaml")
+	}
+
+	raw, err := os.ReadFile(path) // #nosec G304 -- test reads its own temp file
+	if err != nil {
+		t.Fatalf("failed to read config: %v", err)
+	}
+
+	if string(raw) != session.DefaultConfig {
+		t.Error("default config was rewritten despite no changes")
+	}
+}
+
+func TestEnsureDefaultProvidersInConfigEmptyProviders(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("providers:\n"), 0o600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+
+	changed, err := EnsureDefaultProvidersInConfig(path)
+	if err != nil {
+		t.Fatalf("EnsureDefaultProvidersInConfig() error: %v", err)
+	}
+
+	if !changed {
+		t.Fatal("EnsureDefaultProvidersInConfig() = false, want true")
+	}
+
+	provs := configProviders(t, path)
+
+	for _, e := range All() {
+		if !e.DefaultEnabled {
+			continue
+		}
+
+		if _, ok := provs[strings.ToLower(e.Name)]; !ok {
+			t.Errorf("provider %q not added to empty providers section", e.Name)
+		}
+	}
+}
+
+func TestEnsureDefaultProvidersInConfigMissingFile(t *testing.T) {
+	t.Parallel()
+
+	if _, err := EnsureDefaultProvidersInConfig(filepath.Join(t.TempDir(), "missing.yaml")); err == nil {
+		t.Error("EnsureDefaultProvidersInConfig() on missing file: expected error")
 	}
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -13,7 +13,7 @@ import (
 
 // expectedProviderCount is the number of provider entries currently registered
 // in All(). Update this constant if providers are added or removed.
-const expectedProviderCount = 40
+const expectedProviderCount = 41
 
 func TestAllReturnsEntries(t *testing.T) {
 	t.Parallel()

--- a/session/config.yaml
+++ b/session/config.yaml
@@ -47,8 +47,7 @@ providers:
   hetzner:
     enabled: true
   icloudpr:
-    # disabled by default as can slow down old processors
-    enabled: false
+    enabled: true
   ipapi:
     enabled: true
   ipqs:

--- a/session/config.yaml
+++ b/session/config.yaml
@@ -52,6 +52,8 @@ providers:
     enabled: true
   ipqs:
     enabled: true
+  iptoasn:
+    enabled: true
   ipurl:
     enabled: true
     urls:

--- a/session/session.go
+++ b/session/session.go
@@ -241,6 +241,12 @@ type Providers struct {
 		ResultCacheTTL int64  `mapstructure:"result_cache_ttl"`
 		OutputPriority *int32 `mapstructure:"output_priority"`
 	} `mapstructure:"ipapi"`
+	IPToASN struct {
+		Enabled          *bool  `mapstructure:"enabled"`
+		DocumentCacheTTL int64  `mapstructure:"document_cache_ttl"`
+		URL              string `mapstructure:"url"`
+		OutputPriority   *int32 `mapstructure:"output_priority"`
+	} `mapstructure:"iptoasn"`
 	IPQS struct {
 		APIKey         string
 		Enabled        *bool  `mapstructure:"enabled"`

--- a/ui/azure.go
+++ b/ui/azure.go
@@ -12,7 +12,7 @@ import (
 )
 
 func fetchAzure(ip string, sess *session.Session) providerResult {
-	slog.Info("Fetching data from Azure", "ip", ip)
+	slog.Debug("Fetching data from Azure", "ip", ip)
 
 	var err error
 
@@ -33,7 +33,7 @@ func fetchAzure(ip string, sess *session.Session) providerResult {
 		return providerResult{text: simplifyError(err, "azure", ip)}
 	}
 
-	slog.Info("Fetching data from Azure", "ip", ip)
+	slog.Debug("fetched data from Azure", "ip", ip)
 
 	var azureResult azure.HostSearchResult
 	if err := json.Unmarshal([]byte(res), &azureResult); err != nil {

--- a/ui/azurewaf.go
+++ b/ui/azurewaf.go
@@ -12,7 +12,7 @@ import (
 )
 
 func fetchAzureWAF(ip string, sess *session.Session) providerResult { // nolint:dupl
-	slog.Info("Fetching data from Azure WAF", "ip", ip)
+	slog.Debug("Fetching data from Azure WAF", "ip", ip)
 
 	var err error
 
@@ -33,7 +33,7 @@ func fetchAzureWAF(ip string, sess *session.Session) providerResult { // nolint:
 		return providerResult{text: simplifyError(err, "azurewaf", ip)}
 	}
 
-	slog.Info("Fetching data from Azure WAF", "ip", ip)
+	slog.Debug("fetched data from Azure WAF", "ip", ip)
 
 	// Parse Azure WAF JSON response
 	var azureWAFResult azurewaf.HostSearchResult

--- a/ui/iptoasn.go
+++ b/ui/iptoasn.go
@@ -1,0 +1,118 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/jonhadfield/ipscout/helpers"
+	"github.com/jonhadfield/ipscout/providers/iptoasn"
+	"github.com/jonhadfield/ipscout/session"
+	"github.com/rivo/tview"
+)
+
+func fetchIPToASN(ip string, sess *session.Session) providerResult {
+	slog.Debug("Fetching data from IPtoASN", "ip", ip)
+
+	var err error
+
+	sess.Host, err = helpers.ParseHost(ip)
+	if err != nil {
+		slog.Error("Error parsing host for IPtoASN", "ip", ip, "error", err)
+
+		return providerResult{text: simplifyError(err, "iptoasn", ip)}
+	}
+
+	processor := New(sess)
+	sess.Logger.Debug("processor.Run iptoasn")
+
+	res, err := processor.Run(iptoasn.ProviderName)
+	if err != nil {
+		slog.Error("Error fetching data from IPtoASN", "ip", ip, "error", err)
+
+		return providerResult{text: simplifyError(err, "iptoasn", ip)}
+	}
+
+	slog.Debug("fetched data from IPtoASN", "ip", ip)
+
+	var iptoasnResult iptoasn.HostSearchResult
+	if err := json.Unmarshal([]byte(res), &iptoasnResult); err != nil {
+		slog.Error("Failed to parse IPtoASN JSON", "error", err)
+
+		return providerResult{text: simplifyError(err, "iptoasn", ip)}
+	}
+
+	table := createIPToASNTable(ip, &iptoasnResult, false)
+
+	return providerResult{table: table}
+}
+
+func createIPToASNTable(ip string, result *iptoasn.HostSearchResult, isActive bool) *tview.Table {
+	table := tview.NewTable()
+	table.SetBorder(false)
+	table.SetBackgroundColor(tcell.ColorBlack)
+
+	row := 0
+
+	headerText := " IPtoASN | Host: " + ip
+	if isActive {
+		headerText = " ▶ IPtoASN | Host: " + ip
+	}
+
+	table.SetCell(row, 0, tview.NewTableCell(headerText).
+		SetTextColor(tcell.ColorLightCyan).
+		SetSelectable(false))
+
+	row++
+
+	if !result.Announced {
+		table.SetCell(row, 0, tview.NewTableCell(" IP not announced by any AS").
+			SetTextColor(tcell.ColorYellow).
+			SetSelectable(false))
+
+		return table
+	}
+
+	table.SetCell(row, 0, tview.NewTableCell(" ASN").
+		SetTextColor(tcell.ColorWhite).
+		SetSelectable(false))
+	table.SetCell(row, 1, tview.NewTableCell(fmt.Sprintf("AS%d", result.ASNumber)).
+		SetTextColor(tcell.ColorLightCyan).
+		SetSelectable(false))
+
+	row++
+
+	if result.ASDescription != "" {
+		table.SetCell(row, 0, tview.NewTableCell(" AS Name").
+			SetTextColor(tcell.ColorWhite).
+			SetSelectable(false))
+		table.SetCell(row, 1, tview.NewTableCell(result.ASDescription).
+			SetTextColor(tcell.ColorLightCyan).
+			SetSelectable(false))
+
+		row++
+	}
+
+	if result.ASCountryCode != "" {
+		table.SetCell(row, 0, tview.NewTableCell(" Country").
+			SetTextColor(tcell.ColorWhite).
+			SetSelectable(false))
+		table.SetCell(row, 1, tview.NewTableCell(result.ASCountryCode).
+			SetTextColor(tcell.ColorWhite).
+			SetSelectable(false))
+
+		row++
+	}
+
+	if result.FirstIP != "" && result.LastIP != "" {
+		table.SetCell(row, 0, tview.NewTableCell(" Range").
+			SetTextColor(tcell.ColorWhite).
+			SetSelectable(false))
+		table.SetCell(row, 1, tview.NewTableCell(result.FirstIP+" - "+result.LastIP).
+			SetTextColor(tcell.ColorWhite).
+			SetSelectable(false))
+	}
+
+	return table
+}

--- a/ui/main.go
+++ b/ui/main.go
@@ -309,7 +309,7 @@ func OpenUI() error {
 	// sess := session.Session{}
 
 	logger := slog.New(slog.NewTextHandler(logFile, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
+		Level: ProgramLevel,
 	}))
 	slog.SetDefault(logger)
 

--- a/ui/main.go
+++ b/ui/main.go
@@ -64,6 +64,7 @@ const (
 	providerPTR          = "ptr"
 	providerShodan       = "shodan"
 	providerIPAPI        = "ipapi"
+	providerIPToASN      = "iptoasn"
 	providerIPURL        = "ipurl"
 	providerGooglebot    = "googlebot"
 	providerHetzner      = "hetzner"
@@ -95,6 +96,7 @@ var providerIcons = map[string]string{
 	providerPTR:          emojiGlobe,
 	providerShodan:       emojiInvader,
 	providerIPAPI:        emojiGlobe,
+	providerIPToASN:      emojiGlobe,
 	providerIPURL:        emojiGlobe,
 	providerGooglebot:    emojiInvader,
 	providerHetzner:      emojiCloud,
@@ -254,6 +256,8 @@ func addActiveIndicatorToTable(table *tview.Table, providerName string) {
 		switch providerName {
 		case providerIPAPI:
 			newText = strings.Replace(currentText, " IPAPI", " ▶ IPAPI", 1)
+		case providerIPToASN:
+			newText = strings.Replace(currentText, " IPtoASN", " ▶ IPtoASN", 1)
 		case providerIPURL:
 			newText = strings.Replace(currentText, " IP URL", " ▶ IP URL", 1)
 		case providerGooglebot:
@@ -345,6 +349,7 @@ func OpenUI() error {
 		providerPTR:          fetchPTR,
 		providerShodan:       fetchShodan,
 		providerIPAPI:        fetchIPAPI,
+		providerIPToASN:      fetchIPToASN,
 		providerIPURL:        fetchIPURL,
 		providerGooglebot:    fetchGooglebot,
 		providerHetzner:      fetchHetzner,
@@ -370,7 +375,7 @@ func OpenUI() error {
 		providerVultr:        fetchVultr,
 		providerZscaler:      fetchZscaler,
 	}
-	providers := []string{providerPTR, providerAnnotated, providerShodan, providerIPAPI, providerIPURL, providerGooglebot, providerHetzner, providerIPQS, providerAbuseIPDB, providerAlibaba, providerVirusTotal, providerAWS, providerAzure, providerBingbot, providerCriminalIP, providerDigitalOcean, providerGCP, providerGoogle, providerGoogleSC, providerICloudPR, providerLinode, providerM247, providerOpenAI, providerOVH, providerScaleway, providerVultr, providerZscaler}
+	providers := []string{providerPTR, providerAnnotated, providerShodan, providerIPAPI, providerIPToASN, providerIPURL, providerGooglebot, providerHetzner, providerIPQS, providerAbuseIPDB, providerAlibaba, providerVirusTotal, providerAWS, providerAzure, providerBingbot, providerCriminalIP, providerDigitalOcean, providerGCP, providerGoogle, providerGoogleSC, providerICloudPR, providerLinode, providerM247, providerOpenAI, providerOVH, providerScaleway, providerVultr, providerZscaler}
 
 	providerInfo := make(map[string]providerResult)
 	input := tview.NewInputField()

--- a/ui/root.go
+++ b/ui/root.go
@@ -8,6 +8,7 @@ import (
 
 	c "github.com/jonhadfield/ipscout/constants"
 	h "github.com/jonhadfield/ipscout/helpers"
+	"github.com/jonhadfield/ipscout/registry"
 
 	"github.com/jonhadfield/ipscout/session"
 	"github.com/spf13/viper"
@@ -26,6 +27,10 @@ func addProviderConfigMessage(sess *session.Session, provider string) {
 }
 
 func initProviderConfig(sess *session.Session, v *viper.Viper) {
+	// providers requiring no configuration default to enabled when absent
+	// from the user's config file
+	registry.SetEnabledDefaults(v)
+
 	// IP API
 	sess.Providers.IPAPI.APIKey = v.GetString("providers.ipapi.api_key")
 	sess.Providers.IPAPI.ResultCacheTTL = v.GetInt64("providers.ipapi.result_cache_ttl")

--- a/ui/root.go
+++ b/ui/root.go
@@ -401,6 +401,22 @@ func initProviderConfig(sess *session.Session, v *viper.Viper) {
 		sess.Providers.IPAPI.OutputPriority = ToPtr(int32(c.DefaultIPAPIOutputPriority))
 	}
 
+	// IPtoASN
+	if v.IsSet("providers.iptoasn.enabled") {
+		sess.Providers.IPToASN.Enabled = ToPtr(v.GetBool("providers.iptoasn.enabled"))
+	} else {
+		addProviderConfigMessage(sess, "IPtoASN")
+	}
+
+	if v.IsSet("providers.iptoasn.output_priority") {
+		sess.Providers.IPToASN.OutputPriority = ToPtr(v.GetInt32("providers.iptoasn.output_priority"))
+	} else {
+		sess.Providers.IPToASN.OutputPriority = ToPtr(int32(c.DefaultIPToASNOutputPriority))
+	}
+
+	sess.Providers.IPToASN.URL = v.GetString("providers.iptoasn.url")
+	sess.Providers.IPToASN.DocumentCacheTTL = v.GetInt64("providers.iptoasn.document_cache_ttl")
+
 	// VirusTotal
 	if v.IsSet("providers.virustotal.enabled") {
 		sess.Providers.VirusTotal.Enabled = ToPtr(v.GetBool("providers.virustotal.enabled"))

--- a/ui/root.go
+++ b/ui/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strings"
 
 	c "github.com/jonhadfield/ipscout/constants"
@@ -472,6 +473,14 @@ func initConfig() (*session.Session, error) {
 
 	if _, err := session.CreateDefaultConfigIfMissing(configRoot); err != nil {
 		return sess, fmt.Errorf("cannot create default session: %w", err)
+	}
+
+	// add any providers introduced since the user's config was written, so
+	// their config shows all no-config providers as enabled
+	if _, err := registry.EnsureDefaultProvidersInConfig(filepath.Join(configRoot, session.DefaultConfigFileName)); err != nil {
+		sess.Messages.Mu.Lock()
+		sess.Messages.Info = append(sess.Messages.Info, fmt.Sprintf("unable to add new providers to config: %s", err))
+		sess.Messages.Mu.Unlock()
 	}
 
 	v.AddConfigPath(configRoot)


### PR DESCRIPTION
## Summary

Four related changes around provider availability and a new provider:

### Default-enable no-config providers
- Providers that require no configuration (no API key, paths, URLs or resource IDs) are now marked `DefaultEnabled` in the registry and enabled via viper defaults when absent from the user's config, so providers added after a user's config file was written are no longer silently skipped.
- On startup, `EnsureDefaultProvidersInConfig` upgrades an existing user's `config.yaml` in place, appending `enabled: true` entries for any missing no-config providers (including iCloud Private Relay, now also enabled in the shipped default config). Comments, ordering and explicit user settings — including explicit disables — are preserved. Failure to write is non-fatal.
- Config keys are lowercased since some `ProviderName` constants (`M247`) are not, and a guard test ensures the shipped default config always lists every no-config provider.

### Azure logging at debug
- The azure/azurewaf providers and TUI logged routine activity ("azure match found", "Fetching data from Azure") at info; these are now debug. The TUI's global slog handler now honours the shared `ProgramLevel` instead of a hardcoded info level.

### New IPtoASN provider
- Reports the announcing AS number, name, country and address range for a host using the free, hourly-updated `ip2asn-combined.tsv.gz` dataset from [iptoasn.com](https://iptoasn.com/).
- The dataset is downloaded once, cached compressed (24h default TTL, `document_cache_ttl`/`url` configurable) and stream-scanned per lookup with early exit on the sorted ranges; IPv4 and IPv6 supported. The JSON API was not used as Cloudflare bot protection blocks non-browser clients (verified empirically).
- Country-code based rating and threat indicators mirror ipapi. Wired into registry (enabled by default), CLI, TUI and README; provider count is now 41.

## Testing
- New wiring tests: no-config providers enabled on empty config, explicit disable wins, default config completeness, config-file upgrade (comments/ordering/user settings preserved, second run no-op, lowercased keys).
- IPtoASN: test-data path, table rendering, rating paths, and offline network tests covering download → cache → scan including IPv6, no-match, not-routed, download-failure and corrupt-cache cases.
- Verified end-to-end with a built binary: outdated user config upgraded in place; `ipscout 8.8.8.8` renders IPtoASN with AS15169 / GOOGLE / US via a live dataset download; azure logging absent at info, present at debug.
- Full test suite and `make lint` (0 issues) pass.