### PR TITLE
fix: honour log-level flag in TUI instead of hardcoded debug

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -12,7 +12,12 @@ var uiCmd = &cobra.Command{
 	Long:  `Open the IPScout user interface`,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) { //nolint:revive
-		if err := ui.OpenUI(); err != nil {
+		logLevel, err := cmd.Flags().GetString("log-level")
+		if err != nil {
+			logLevel = ""
+		}
+
+		if err := ui.OpenUI(logLevel); err != nil {
 			cmd.PrintErrln(err)
 		}
 	},

--- a/ui/main.go
+++ b/ui/main.go
@@ -288,7 +288,7 @@ func addActiveIndicatorToTable(table *tview.Table, providerName string) {
 	}
 }
 
-func OpenUI() error {
+func OpenUI(logLevel string) error {
 	// Setup logging to app.log
 	logFile, err := os.OpenFile(LogFileName, os.O_CREATE|os.O_WRONLY|os.O_APPEND, LogFilePerms)
 	if err != nil {
@@ -301,7 +301,7 @@ func OpenUI() error {
 		}
 	}()
 
-	sess, err = initConfig()
+	sess, err = initConfig(logLevel)
 	if err != nil {
 		slog.Error("Failed to initialise session", "error", err)
 

--- a/ui/root.go
+++ b/ui/root.go
@@ -472,7 +472,7 @@ func initSessionConfig(sess *session.Session, v *viper.Viper) {
 	sess.Config.Rating.OpenAIAPIKey = v.GetString("rating.openai_api_key")
 }
 
-func initConfig() (*session.Session, error) {
+func initConfig(logLevel string) (*session.Session, error) {
 	v := viper.New()
 
 	// create session
@@ -519,7 +519,7 @@ func initConfig() (*session.Session, error) {
 	initSessionConfig(sess, v)
 
 	// initialise logging
-	if err := initLogging(); err != nil {
+	if err := initLogging(logLevel); err != nil {
 		return sess, err
 	}
 
@@ -577,13 +577,11 @@ func initConfig() (*session.Session, error) {
 
 var ProgramLevel = new(slog.LevelVar) // Info by default
 
-func initLogging() error {
+func initLogging(logLevel string) error {
 	hOptions := slog.HandlerOptions{AddSource: false}
 
-	ll := "DEBUG"
-
 	// set log level
-	switch strings.ToUpper(ll) {
+	switch strings.ToUpper(logLevel) {
 	case "ERROR":
 		ProgramLevel.Set(slog.LevelError)
 
@@ -600,6 +598,11 @@ func initLogging() error {
 		ProgramLevel.Set(slog.LevelDebug)
 
 		sess.HideProgress = true
+	default:
+		// match the CLI's default log level
+		ProgramLevel.Set(slog.LevelWarn)
+
+		sess.HideProgress = false
 	}
 
 	hOptions.Level = ProgramLevel


### PR DESCRIPTION
## Summary

`ipscout ui` hardcoded its log level to DEBUG, so every debug diagnostic (including all the Azure activity demoted in #117) was still written to `app.log` even when the user hadn't asked for debug. The TUI now honours the root `--log-level` flag, defaulting to WARN like the CLI, with unrecognised values also falling back to WARN.

- `cmd/ui.go` reads the persistent `--log-level` flag and passes it to `ui.OpenUI`
- `ui/root.go` `initLogging` takes the level instead of hardcoding `"DEBUG"`, with a WARN default case
- The TUI's global slog handler already follows `ProgramLevel`, so both loggers respect the flag

## Testing

- Full test suite and `make lint` (0 issues) pass
- `ipscout ui` now writes only warn+ to `app.log` by default; `ipscout --log-level DEBUG ui` restores the full diagnostics