### PR TITLE
chore: migrate goreleaser config off deprecated options

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,12 +35,12 @@ builds:
 archives:
   - id: default
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-    format: tar.gz
-    builds:
+    formats: ["tar.gz"]
+    ids:
       - ipscout
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
     files:
       - license*
       - readme*
@@ -60,7 +60,7 @@ release:
     - glob: ./dist/ipscout_darwin*.zip
 
 snapshot:
-  name_template: "{{ .Tag }}-devel"
+  version_template: "{{ .Tag }}-devel"
 
 changelog:
   sort: asc
@@ -70,14 +70,22 @@ changelog:
       - test
       - ignore
 
-brews:
+homebrew_casks:
   - name: ipscout
     homepage: https://github.com/jonhadfield/ipscout
-    description: >
+    description: >-
       A command line tool for network administrators and security analysts to quickly identify the origin and threat of an IP address.
     repository:
       owner: jonhadfield
       name: homebrew-ipscout
+    # the binaries are unsigned, so clear the quarantine attribute on
+    # install to avoid Gatekeeper blocking them
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ipscout"]
+          end
 
 announce:
   skip: true


### PR DESCRIPTION
## Summary

The 0.6.x releases warned about five deprecated goreleaser options. All are migrated (goreleaser 2.17.1):

- `archives.format` → `formats: ["tar.gz"]`, `format_overrides.format` → `formats: ["zip"]`
- `archives.builds` → `ids`
- `snapshot.name_template` → `version_template`
- `brews` → `homebrew_casks`, with a postflight hook clearing the macOS quarantine attribute since the release binaries are unsigned (the goreleaser-recommended migration). The deprecated `conflicts.formula` stanza was not carried over — it's a no-op removed from Homebrew.

## Behavioural note

From the next release, goreleaser pushes `Casks/ipscout.rb` to the `jonhadfield/homebrew-ipscout` tap instead of the root formula. The old `ipscout.rb` formula should be deleted from the tap repo after the first cask release, and existing brew users will be migrated by `brew upgrade` picking up the cask from the tap.

## Testing

- `goreleaser check`: configuration valid, zero deprecation warnings
- Full snapshot release (`goreleaser release --snapshot --clean`) succeeds; generated cask verified: per-platform URLs and checksums, `binary "ipscout"` stanza and quarantine postflight all render correctly