### PR TITLE
docs: note homebrew cask migration for pre-0.6.2 formula installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ $ brew tap jonhadfield/ipscout
 $ brew install ipscout
 ```
 
+Since 0.6.2, ipscout is distributed as a Homebrew cask. If you installed an earlier
+version (distributed as a formula), reinstall once to migrate:
+
+```
+$ brew uninstall ipscout
+$ brew install ipscout
+```
+
 ### Linux
 Install latest release.
 ```shell


### PR DESCRIPTION
## Summary

Since 0.6.2 the tap distributes ipscout as a Homebrew cask (the old root formula was removed). The tap + install commands are unchanged, but users who installed the pre-0.6.2 formula need a one-time `brew uninstall ipscout && brew install ipscout` to migrate — this documents that in the macOS install section.