### PR TITLE
docs: add 0.6.4 changelog entry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.4] - 2026-07-28
+### Changed
+- backfill changelog with release notes for 0.3.0 through 0.6.3
+
 ## [0.6.3] - 2026-07-28
 ### Changed
 - bump otel and klauspost/compress to clear govulncheck findings


### PR DESCRIPTION
Adds the 0.6.4 entry (the changelog backfill release) to docs/CHANGELOG.md.