### PR TITLE
fix: align azwaf logrus logging with the session log level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/miekg/dns v1.1.72
 	github.com/rivo/tview v0.42.0
 	github.com/sashabaranov/go-openai v1.41.2
+	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -92,7 +93,6 @@ require (
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
-	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/providers/azurewaf/azurewaf.go
+++ b/providers/azurewaf/azurewaf.go
@@ -24,6 +24,7 @@ import (
 	azwafSession "github.com/jonhadfield/azwaf/session"
 	"github.com/jonhadfield/ipscout/providers"
 	"github.com/jonhadfield/ipscout/session"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -45,6 +46,16 @@ type ProviderClient struct {
 
 func NewProviderClient(c session.Session) (providers.ProviderClient, error) {
 	c.Logger.Debug("creating azurewaf client")
+
+	// azwaf logs via the global logrus logger, which defaults to info on
+	// stderr regardless of ipscout's log level; align it so azure waf
+	// diagnostics only appear at the level the user asked for
+	logrusLevel, err := logrus.ParseLevel(strings.ToLower(c.Config.Global.LogLevel))
+	if err != nil {
+		logrusLevel = logrus.WarnLevel
+	}
+
+	logrus.SetLevel(logrusLevel)
 
 	tc := &ProviderClient{
 		Session: c,

--- a/ui/root.go
+++ b/ui/root.go
@@ -580,6 +580,8 @@ var ProgramLevel = new(slog.LevelVar) // Info by default
 func initLogging(logLevel string) error {
 	hOptions := slog.HandlerOptions{AddSource: false}
 
+	sess.Config.Global.LogLevel = logLevel
+
 	// set log level
 	switch strings.ToUpper(logLevel) {
 	case "ERROR":


### PR DESCRIPTION
The azwaf library used by the azurewaf provider logs through the global logrus logger — `GetRawPolicy` and the session client code emit info-level diagnostics ("Starting GetRawPolicy...", client creation timings) straight to stderr at logrus's default info level, ignoring ipscout's `--log-level` entirely, since logrus is independent of slog.

Set the global logrus level from the session log level when the azurewaf provider client is created (falling back to warn, matching the CLI default), and store the TUI's log level in session config so both entrypoints feed it. azure waf diagnostics now appear only at the requested level: hidden at the default WARN, visible with `--log-level INFO`/`DEBUG` as appropriate. logrus moves from indirect to direct in go.mod; no new dependency (it was already in the graph via azwaf).