### PR TITLE
docs: add 0.6.6 changelog entry

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.6] - 2026-08-02
+### Fixed
+- azure waf diagnostics from the azwaf library now respect the configured log level
+  instead of always printing at info
+
 ## [0.6.5] - 2026-07-30
 ### Changed
 - changelog updates


### PR DESCRIPTION
Adds the 0.6.6 entry ahead of the release, covering the azwaf log-level fix.